### PR TITLE
feat: add small caps conversion utility

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.3.0-SNAPSHOT
+version=1.21.4-2.4.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/font/small-caps.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/font/small-caps.kt
@@ -1,0 +1,23 @@
+package dev.slne.surf.surfapi.core.api.font
+
+import dev.slne.surf.surfapi.core.api.util.char2CharMapOf
+
+private val smallCapsMap = char2CharMapOf(
+    'a' to 'ᴀ', 'b' to 'ʙ', 'c' to 'ᴄ', 'd' to 'ᴅ', 'e' to 'ᴇ', 'f' to 'ғ',
+    'g' to 'ɢ', 'h' to 'ʜ', 'i' to 'ɪ', 'j' to 'ᴊ', 'k' to 'ᴋ', 'l' to 'ʟ',
+    'm' to 'ᴍ', 'n' to 'ɴ', 'o' to 'ᴏ', 'p' to 'ᴘ', 'q' to 'ǫ', 'r' to 'ʀ',
+    's' to 's', 't' to 'ᴛ', 'u' to 'ᴜ', 'v' to 'ᴠ', 'w' to 'ᴡ', 'x' to 'x',
+    'y' to 'ʏ', 'z' to 'ᴢ',
+    '0' to '0', '1' to '1', '2' to '2', '3' to '3', '4' to '4',
+    '5' to '5', '6' to '6', '7' to '7', '8' to '8', '9' to '9'
+)
+
+
+fun String.toSmallCaps(): String {
+    val result = StringBuilder(length)
+    for (char in this) {
+        result.append(smallCapsMap.getOrDefault(char.lowercaseChar(), char))
+    }
+
+    return result.toString()
+}


### PR DESCRIPTION
This pull request includes updates to the project version and the addition of a new utility function for converting strings to small caps. The most important changes are summarized below:

Version update:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version from `1.21.4-2.3.0-SNAPSHOT` to `1.21.4-2.4.0-SNAPSHOT`.

New utility function:

* [`surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/font/small-caps.kt`](diffhunk://#diff-1bf57f07d4c0bb9a5cfdb4537c0fa693c9eb0127cb9e0791e2cabdde09d21a13R1-R23): Added a new `toSmallCaps` extension function for `String` that converts characters to their small caps equivalents using a predefined map.