### PR TITLE
feat: add Javadoc options to enhance API documentation

### DIFF
--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -69,4 +69,10 @@ tasks {
     shadowJar {
         mergeServiceFiles()
     }
+
+    javadoc {
+        val options = options as StandardJavadocDocletOptions
+        options.use()
+        options.tags("apiNote:a:API Note:")
+    }
 }


### PR DESCRIPTION
This pull request includes a change to the `buildSrc/src/main/kotlin/core-convention.gradle.kts` file to enhance the Javadoc generation process by adding specific Javadoc options.

Enhancements to Javadoc generation:

* [`buildSrc/src/main/kotlin/core-convention.gradle.kts`](diffhunk://#diff-5a51cb93c1412ae49a475aec86c766d8248bf186e435b09da9e5ec11f674c776R72-R77): Added a `javadoc` task with options to enable the use of Javadoc tags and to define custom tags for API notes.