### PR TITLE
feat: update version to 1.21.4-2.7.0-SNAPSHOT and add ktor-client-con…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.6.0-SNAPSHOT
+version=1.21.4-2.7.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,6 +143,7 @@ auto-service-annotations = { module = "com.google.auto.service:auto-service-anno
 auto-service = { module = "dev.zacsweers.autoservice:auto-service-ksp", version.ref = "auto-service-ksp" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 
 # Plugin dependencies
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }
@@ -165,4 +166,4 @@ kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", versi
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp-gradle-plugin" }
 
 [bundles]
-ktor-client = ["ktor-client-core", "ktor-client-okhttp"]
+ktor-client = ["ktor-client-core", "ktor-client-okhttp", "ktor-client-content-negotiation"]

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -6136,6 +6136,31 @@ public final class io/ktor/client/plugins/cache/storage/HttpCacheStorageKt {
 	public static synthetic fun store$default (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/plugins/contentnegotiation/ContentConverterException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationConfig : io/ktor/serialization/Configuration {
+	public fun <init> ()V
+	public final fun clearIgnoredTypes ()V
+	public final fun getDefaultAcceptHeaderQValue ()Ljava/lang/Double;
+	public final fun ignoreType (Lkotlin/reflect/KClass;)V
+	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lio/ktor/http/ContentTypeMatcher;Lkotlin/jvm/functions/Function1;)V
+	public fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lkotlin/jvm/functions/Function1;)V
+	public final fun removeIgnoredType (Lkotlin/reflect/KClass;)V
+	public final fun setDefaultAcceptHeaderQValue (Ljava/lang/Double;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationKt {
+	public static final fun exclude (Lio/ktor/client/request/HttpRequestBuilder;[Lio/ktor/http/ContentType;)V
+	public static final fun getContentNegotiation ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher : io/ktor/http/ContentTypeMatcher {
+	public static final field INSTANCE Lio/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher;
+	public fun contains (Lio/ktor/http/ContentType;)Z
+}
+
 public final class io/ktor/client/plugins/cookies/AcceptAllCookiesStorage : io/ktor/client/plugins/cookies/CookiesStorage {
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V

--- a/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
+++ b/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
@@ -4900,6 +4900,31 @@ public final class io/ktor/client/plugins/cache/storage/HttpCacheStorageKt {
 	public static synthetic fun store$default (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/plugins/contentnegotiation/ContentConverterException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationConfig : io/ktor/serialization/Configuration {
+	public fun <init> ()V
+	public final fun clearIgnoredTypes ()V
+	public final fun getDefaultAcceptHeaderQValue ()Ljava/lang/Double;
+	public final fun ignoreType (Lkotlin/reflect/KClass;)V
+	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lio/ktor/http/ContentTypeMatcher;Lkotlin/jvm/functions/Function1;)V
+	public fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lkotlin/jvm/functions/Function1;)V
+	public final fun removeIgnoredType (Lkotlin/reflect/KClass;)V
+	public final fun setDefaultAcceptHeaderQValue (Ljava/lang/Double;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationKt {
+	public static final fun exclude (Lio/ktor/client/request/HttpRequestBuilder;[Lio/ktor/http/ContentType;)V
+	public static final fun getContentNegotiation ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher : io/ktor/http/ContentTypeMatcher {
+	public static final field INSTANCE Lio/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher;
+	public fun contains (Lio/ktor/http/ContentType;)Z
+}
+
 public final class io/ktor/client/plugins/cookies/AcceptAllCookiesStorage : io/ktor/client/plugins/cookies/CookiesStorage {
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V

--- a/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
+++ b/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
@@ -5136,6 +5136,31 @@ public final class io/ktor/client/plugins/cache/storage/HttpCacheStorageKt {
 	public static synthetic fun store$default (Lio/ktor/client/plugins/cache/storage/CacheStorage;Lio/ktor/client/statement/HttpResponse;Ljava/util/Map;ZLkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
+public final class io/ktor/client/plugins/contentnegotiation/ContentConverterException : java/lang/Exception {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationConfig : io/ktor/serialization/Configuration {
+	public fun <init> ()V
+	public final fun clearIgnoredTypes ()V
+	public final fun getDefaultAcceptHeaderQValue ()Ljava/lang/Double;
+	public final fun ignoreType (Lkotlin/reflect/KClass;)V
+	public final fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lio/ktor/http/ContentTypeMatcher;Lkotlin/jvm/functions/Function1;)V
+	public fun register (Lio/ktor/http/ContentType;Lio/ktor/serialization/ContentConverter;Lkotlin/jvm/functions/Function1;)V
+	public final fun removeIgnoredType (Lkotlin/reflect/KClass;)V
+	public final fun setDefaultAcceptHeaderQValue (Ljava/lang/Double;)V
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/ContentNegotiationKt {
+	public static final fun exclude (Lio/ktor/client/request/HttpRequestBuilder;[Lio/ktor/http/ContentType;)V
+	public static final fun getContentNegotiation ()Lio/ktor/client/plugins/api/ClientPlugin;
+}
+
+public final class io/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher : io/ktor/http/ContentTypeMatcher {
+	public static final field INSTANCE Lio/ktor/client/plugins/contentnegotiation/JsonContentTypeMatcher;
+	public fun contains (Lio/ktor/http/ContentType;)Z
+}
+
 public final class io/ktor/client/plugins/cookies/AcceptAllCookiesStorage : io/ktor/client/plugins/cookies/CookiesStorage {
 	public fun <init> ()V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V


### PR DESCRIPTION
This pull request includes updates to the project dependencies and the addition of new classes related to the Ktor client content negotiation plugin. The most important changes include updating the project version, adding new dependencies, and defining new classes for content negotiation in the Ktor client.

Dependency updates:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version from `1.21.4-2.6.0-SNAPSHOT` to `1.21.4-2.7.0-SNAPSHOT`.
* [`gradle/libs.versions.toml`](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR146): Added `ktor-client-content-negotiation` dependency and included it in the `ktor-client` bundle. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR146) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL168-R169)

New classes for Ktor client content negotiation:

* [`surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR6139-R6163): Added classes `ContentConverterException`, `ContentNegotiationConfig`, `ContentNegotiationKt`, and `JsonContentTypeMatcher` for Ktor client content negotiation.
* [`surf-api-core/surf-api-core-api/api/surf-api-core-api.api`](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R4903-R4927): Added the same set of classes for Ktor client content negotiation.
* [`surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api`](diffhunk://#diff-cfabe3feaa79fe3574d3bd2351f48434d7fb42e0ab926ec7fd9b3861f1301279R5139-R5163): Added the same set of classes for Ktor client content negotiation.