### PR TITLE
feat: update version to 1.21.4-2.8.0-SNAPSHOT and refactor item stack…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.7.0-SNAPSHOT
+version=1.21.4-2.8.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/builder/item-stack.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/builder/item-stack.kt
@@ -1,26 +1,36 @@
 package dev.slne.surf.surfapi.bukkit.api.builder
 
+import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
+import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.TextDecoration
 import org.bukkit.Material
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 
-@Target(AnnotationTarget.TYPE)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 @DslMarker
-annotation class ItemMarker
+annotation class ItemDsl
 
 inline fun buildItem(
     material: Material,
     amount: Int = 1,
-    init: (@ItemMarker ItemStack).() -> Unit,
+    init: (@ItemDsl ItemStack).() -> Unit,
 ): ItemStack {
     val item = ItemStack(material, amount)
     item.init()
     return item
 }
 
-inline fun <reified M : ItemMeta> ItemStack.meta(block: (@ItemMarker M).() -> Unit): Boolean {
+inline fun ItemStack(
+    material: Material,
+    amount: Int = 1,
+    init: (@ItemDsl ItemStack).() -> Unit,
+): ItemStack {
+    return buildItem(material, amount, init)
+}
+
+inline fun <reified M : ItemMeta> ItemStack.meta(block: (@ItemDsl M).() -> Unit): Boolean {
     val meta = itemMeta as? M ?: return false
     meta.block()
     itemMeta = meta
@@ -28,7 +38,7 @@ inline fun <reified M : ItemMeta> ItemStack.meta(block: (@ItemMarker M).() -> Un
 }
 
 @JvmName("meta0")
-inline fun ItemStack.meta(init: (@ItemMarker ItemMeta).() -> Unit) {
+inline fun ItemStack.meta(init: (@ItemDsl ItemMeta).() -> Unit) {
     meta<ItemMeta>(init)
 }
 
@@ -42,4 +52,25 @@ fun ItemStack.lore(vararg lore: Component) {
     meta {
         lore(lore.map { it.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE) })
     }
+}
+
+fun ItemStack.lore(block: @ItemDsl SurfComponentBuilder.() -> Unit) {
+    lore(SurfComponentBuilder().apply(block).build())
+}
+
+fun ItemStack.buildLore(block: @ItemDsl LoreBuilder.() -> Unit) {
+    val loreBuilder = LoreBuilder().apply(block)
+    lore(loreBuilder.build())
+}
+
+@ItemDsl
+class LoreBuilder {
+    private val lore = mutableObjectListOf<Component>()
+
+    fun line(block: @ItemDsl SurfComponentBuilder.() -> Unit) {
+        lore.add(SurfComponentBuilder().apply(block).build())
+    }
+
+    internal fun build() =
+        lore.map { it.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE) }
 }


### PR DESCRIPTION
This pull request includes changes to the `gradle.properties` file and the `item-stack.kt` file to update the version and enhance the item stack builder functionality.

Version update:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version from `1.21.4-2.7.0-SNAPSHOT` to `1.21.4-2.8.0-SNAPSHOT`.

Enhancements to item stack builder:

* `surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/builder/item-stack.kt`: 
  * Added imports for `SurfComponentBuilder` and `mutableObjectListOf`.
  * Changed the annotation class name from `ItemMarker` to `ItemDsl` and updated the `buildItem` and `meta` functions to use the new annotation.
  * Added new overloaded `buildItem` function to create an `ItemStack` with a specified material and amount.
  * Introduced new `lore` and `buildLore` functions to build item lore using a DSL.
  * Created a `LoreBuilder` class to facilitate building lore lines with a DSL.