### PR TITLE
forgot to generate binary diff

### DIFF
--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -995,15 +995,24 @@ public final class dev/slne/surf/surfapi/bukkit/api/SurfBukkitApiKt {
 	public static final fun getSurfBukkitApi ()Ldev/slne/surf/surfapi/bukkit/api/SurfBukkitApi;
 }
 
-public abstract interface annotation class dev/slne/surf/surfapi/bukkit/api/builder/ItemMarker : java/lang/annotation/Annotation {
+public abstract interface annotation class dev/slne/surf/surfapi/bukkit/api/builder/ItemDsl : java/lang/annotation/Annotation {
 }
 
 public final class dev/slne/surf/surfapi/bukkit/api/builder/Item_stackKt {
+	public static final fun ItemStack (Lorg/bukkit/Material;ILkotlin/jvm/functions/Function1;)Lorg/bukkit/inventory/ItemStack;
+	public static synthetic fun ItemStack$default (Lorg/bukkit/Material;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/bukkit/inventory/ItemStack;
 	public static final fun buildItem (Lorg/bukkit/Material;ILkotlin/jvm/functions/Function1;)Lorg/bukkit/inventory/ItemStack;
 	public static synthetic fun buildItem$default (Lorg/bukkit/Material;ILkotlin/jvm/functions/Function1;ILjava/lang/Object;)Lorg/bukkit/inventory/ItemStack;
+	public static final fun buildLore (Lorg/bukkit/inventory/ItemStack;Lkotlin/jvm/functions/Function1;)V
 	public static final fun displayName (Lorg/bukkit/inventory/ItemStack;Lnet/kyori/adventure/text/Component;)V
+	public static final fun lore (Lorg/bukkit/inventory/ItemStack;Lkotlin/jvm/functions/Function1;)V
 	public static final fun lore (Lorg/bukkit/inventory/ItemStack;[Lnet/kyori/adventure/text/Component;)V
 	public static final fun meta0 (Lorg/bukkit/inventory/ItemStack;Lkotlin/jvm/functions/Function1;)V
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/builder/LoreBuilder {
+	public fun <init> ()V
+	public final fun line (Lkotlin/jvm/functions/Function1;)V
 }
 
 public final class dev/slne/surf/surfapi/bukkit/api/collections/LazyIntList {


### PR DESCRIPTION
This pull request includes changes to the `surf-api-bukkit-api` module, focusing on the `ItemStack` and `LoreBuilder` functionalities. The changes primarily introduce new methods for item stack manipulation and lore building, as well as renaming an annotation class for clarity.

New methods for item stack manipulation and lore building:

* [`surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL998-R1017): Added new methods `ItemStack`, `ItemStack$default`, `buildLore`, and `lore` to the `Item_stackKt` class to enhance item stack creation and lore management.
* [`surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL998-R1017): Introduced the `LoreBuilder` class with a constructor and a `line` method to facilitate lore construction.

Renaming for clarity:

* [`surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL998-R1017): Renamed the `ItemMarker` annotation class to `ItemDsl` to better reflect its purpose.