### PR TITLE
feat: add kapt plugin for annotation processing and update version to…

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -46,49 +46,6 @@
         </processorPath>
         <module name="surf-api-velocity-server.surf-api.surf-api-velocity.surf-api-velocity-server.main" />
       </profile>
-      <profile name="Gradle Imported" enabled="true">
-        <outputRelativeToContentRoot value="true" />
-        <processorPath useClasspath="false">
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.velocitypowered/velocity-api/3.4.0-SNAPSHOT/f5a5f61365526e6140008bb8a164322f274e86ae/velocity-api-3.4.0-SNAPSHOT.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.moandjiezana.toml/toml4j/0.7.2/a03337911d0bd2c40932aca3946edb30d0e7d0c/toml4j-0.7.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.spongepowered/configurate-gson/4.1.2/3e5c7a0ea73e95ce6139fa72f1b6d36eb531ab81/configurate-gson-4.1.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-logger-slf4j/4.19.0/2b01ef7f0612daf773a5ba2d551abc8439ef5bf7/adventure-text-logger-slf4j-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-minimessage/4.19.0/813090f1054797c9b54115224e9d8e747bf33d99/adventure-text-minimessage-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-serializer-ansi/4.19.0/6291ed3168fb0df137f93d27bb61a63af4f50955/adventure-text-serializer-ansi-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-serializer-legacy/4.19.0/3cd3c465f11876e27837c5f5df65206373434009/adventure-text-serializer-legacy-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-serializer-plain/4.19.0/c6e1aab74a9bf31454aa4591647a6b509c989563/adventure-text-serializer-plain-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-serializer-json/4.19.0/4b49792a946c4886c5be44881c07c72d8ef6204/adventure-text-serializer-json-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-api/4.19.0/bcfa6effcf8a041bf65b6ebc4c105eef553a5d37/adventure-api-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-key/4.19.0/4ceaae96f0a792f3b391980e0ee5c5695d54efac/adventure-key-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/adventure-text-serializer-gson/4.19.0/57e8dbac7b1a557857833ac661156e1913ddab35/adventure-text-serializer-gson-4.19.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.code.gson/gson/2.10.1/b3add478d4382b78ea20b1671390a858002feb6c/gson-2.10.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.inject/guice/6.0.0/9b422c69c4fa1ea95b2615444a94fede9b02fc40/guice-6.0.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.guava/guava/31.0.1-jre/119ea2b2bc205b138974d351777b20f02b92704b/guava-31.0.1-jre.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.spongepowered/configurate-yaml/4.1.2/f726180c21ec387be5b8a2e04d916443c4046207/configurate-yaml-4.1.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.yaml/snakeyaml/1.33/2cd0a87ff7df953f810c344bdf2fe3340b954c69/snakeyaml-1.33.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.slf4j/slf4j-api/2.0.12/48f109a2a6d8f446c794f3e3fa0d86df0cdfa312/slf4j-api-2.0.12.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.github.ben-manes.caffeine/caffeine/3.1.8/24795585df8afaf70a2cd534786904ea5889c047/caffeine-3.1.8.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.checkerframework/checker-qual/3.42.0/638ec33f363a94d41a4f03c3e7d3dcfba64e402d/checker-qual-3.42.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.velocitypowered/velocity-brigadier/1.0.0-SNAPSHOT/719dd1bda540a9be7f70f23c68fbe1a0e2fc69ca/velocity-brigadier-1.0.0-SNAPSHOT.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.spongepowered/configurate-hocon/4.1.2/3953a4aef8ff62c72d34e405d6df333f3876592a/configurate-hocon-4.1.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.code.findbugs/jsr305/3.0.2/25ea2e8b0c338a877313bd4672d3fe056ea78f0d/jsr305-3.0.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.errorprone/error_prone_annotations/2.21.1/6d9b10773b5237df178a7b3c1b4208df7d0e7f94/error_prone_annotations-2.21.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.j2objc/j2objc-annotations/1.3/ba035118bc8bac37d7eff77700720999acd9986d/j2objc-annotations-1.3.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/javax.inject/javax.inject/1/6975da39a7040257bd51d21a231b76c915872d38/javax.inject-1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/jakarta.inject/jakarta.inject-api/2.0.1/4c28afe1991a941d7702fe1362c365f0a8641d1e/jakarta.inject-api-2.0.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/aopalliance/aopalliance/1.0/235ba8b489512805ac13a8f9ea77a1ca5ebe3e8/aopalliance-1.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.typesafe/config/1.4.1/19058a07624a87f90d129af7cd9c68bee94535a9/config-1.4.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/org.spongepowered/configurate-core/4.1.2/d6728b04738e73847f6a26349cf4368362feab97/configurate-core-4.1.2.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/examination-string/1.3.0/6f34afef5c54ccce4996bc321abf77518b55b4bd/examination-string-1.3.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/examination-api/1.3.0/8a2d185275307f1e2ef2adf7152b9a0d1d44c30b/examination-api-1.3.0.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/ansi/1.1.1/beeb71e49b25cac87c22975014e74c7b5940d1b7/ansi-1.1.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.guava/failureaccess/1.0.1/1dcf1de382a0bf95a3d8b0849546c88bac1292c9/failureaccess-1.0.1.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/b421526c5f297295adef1c886e5246c39d4ac629/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/io.leangen.geantyref/geantyref/1.3.11/bc9c03b53917314d21fe6276aceb08aa84bf80dd/geantyref-1.3.11.jar" />
-          <entry name="$USER_HOME$/scoop/apps/gradle/current/.gradle/caches/modules-2/files-2.1/net.kyori/option/1.0.0/59c5ae54c47ae294322ad979eaf7cdcde7ad0646/option-1.0.0.jar" />
-        </processorPath>
-        <module name="dev.slne.surf.surf-api.surf-api-velocity.surf-api-velocity-server.main" />
-      </profile>
     </annotationProcessing>
     <bytecodeTargetLevel target="17">
       <module name="Deniz.IdeaProjects.surf-api.surf-api-generator.test" target="21" />

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.8.0-SNAPSHOT
+version=1.21.4-2.8.1-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
+++ b/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     `core-convention`
+    kotlin("kapt")
 }
 
 dependencies {
@@ -23,148 +24,10 @@ tasks {
         val relocationPrefix: String by project
         relocate("it.unimi.dsi.fastutil", "$relocationPrefix.fastutil")
     }
-
-//    shadowJar {
-        // Thank you velocity for using fastutil but excluding the types we need - https://github.com/PaperMC/Velocity/blob/dev/3.0.0/proxy/build.gradle.kts#L30
-//        exclude("it/unimi/dsi/fastutil/ints/*Int2Object*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntCo*")
-//        exclude("it/unimi/dsi/fastutil/ints/AbstractIntList*")
-//        exclude("it/unimi/dsi/fastutil/ints/*Int*Set*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntSpliterator*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntStack*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntBoolean*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntByte*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntChar*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntDouble*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntFloat*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntInt*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntLong*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntObject*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntReference*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntShort*Pair*")
-//        exclude("it/unimi/dsi/fastutil/ints/IntHash*")
-//        exclude("it/unimi/dsi/fastutil/ints/IntImmutableList*")
-//        exclude("it/unimi/dsi/fastutil/ints/Int*IndirectHeaps*")
-//        exclude("it/unimi/dsi/fastutil/ints/*IntItera*")
-//        exclude("it/unimi/dsi/fastutil/ints/IntPredicate*")
-//        exclude("it/unimi/dsi/fastutil/ints/IntSpliterator*")
-//        exclude("it/unimi/dsi/fastutil/ints/IntUnaryOperator*")
-//        exclude("it/unimi/dsi/fastutil/ints/package-info*")
-//
-//        exclude("it/unimi/dsi/fastutil/objects/*Object2Int*")
-//        exclude("it/unimi/dsi/fastutil/objects/*Object*Itera*")
-//        exclude("it/unimi/dsi/fastutil/objects/*Object*itera*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectCollection*")
-//        exclude("it/unimi/dsi/fastutil/objects/*Object*List*")
-//////        exclude("it/unimi/dsi/fastutil/objects/*Object*Set*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectArraySet*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectBoolean*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectByte*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectChar*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectDouble*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectFloat*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectInt*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectLong*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectObject*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectShort*Pair*")
-//        exclude("it/unimi/dsi/fastutil/objects/*ObjectComparators*")
-//        exclude("it/unimi/dsi/fastutil/objects/*Object*Heap*")
-//////        exclude("it/unimi/dsi/fastutil/objects/*Object*Set*")
-//        exclude("it/unimi/dsi/fastutil/objects/package-info*")
-//
-//        exclude("it/unimi/dsi/fastutil/*Abstract*")
-//        exclude("it/unimi/dsi/fastutil/*Array*")
-//        exclude("it/unimi/dsi/fastutil/*Bi*")
-//        exclude("it/unimi/dsi/fastutil/*Function*")
-//        exclude("it/unimi/dsi/fastutil/*Hash*")
-//        exclude("it/unimi/dsi/fastutil/*Queue*")
-//        exclude("it/unimi/dsi/fastutil/*Pair*")
-//        exclude("it/unimi/dsi/fastutil/*Math*")
-//        exclude("it/unimi/dsi/fastutil/*Size*")
-//        exclude("it/unimi/dsi/fastutil/*Stack*")
-//        exclude("it/unimi/dsi/fastutil/*Swapper*")
-//        exclude("it/unimi/dsi/fastutil/package-info*")
-//
-////        relocate("it.unimi.dsi.fastutil", "dev.slne.fastutil")
-////          it.unimi.dsi.fastutil.objects.ObjectSets
-//        exclude("it/unimi/dsi/fastutil/object/ObjectSets")
-//        exclude("it/unimi/dsi/fastutil/object/Object2BooleanMaps")
-//        exclude("it/unimi/dsi/fastutil/objects/ObjectArraySet")
-//    }
 }
 
-//configurations {
-//    runtimeClasspath {
-//        resolutionStrategy {
-//            eachDependency {
-//                if (requested.group == "it.unimi.dsi" && requested.name == "fastutil") {
-//                    exclude("it/unimi/dsi/fastutil/ints/*Int2Object*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntCo*")
-//                    exclude("it/unimi/dsi/fastutil/ints/AbstractIntList*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*Int*Set*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntSpliterator*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntStack*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntBoolean*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntByte*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntChar*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntDouble*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntFloat*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntInt*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntLong*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntObject*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntReference*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntShort*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/ints/IntHash*")
-//                    exclude("it/unimi/dsi/fastutil/ints/IntImmutableList*")
-//                    exclude("it/unimi/dsi/fastutil/ints/Int*IndirectHeaps*")
-//                    exclude("it/unimi/dsi/fastutil/ints/*IntItera*")
-//                    exclude("it/unimi/dsi/fastutil/ints/IntPredicate*")
-//                    exclude("it/unimi/dsi/fastutil/ints/IntSpliterator*")
-//                    exclude("it/unimi/dsi/fastutil/ints/IntUnaryOperator*")
-//                    exclude("it/unimi/dsi/fastutil/ints/package-info*")
-//
-//                    exclude("it/unimi/dsi/fastutil/objects/*Object2Int*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*Object*Itera*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*Object*itera*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectCollection*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*Object*List*")
-//////        exclude("it/unimi/dsi/fastutil/objects/*Object*Set*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectArraySet*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectBoolean*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectByte*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectChar*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectDouble*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectFloat*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectInt*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectLong*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectObject*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectShort*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*ObjectComparators*")
-//                    exclude("it/unimi/dsi/fastutil/objects/*Object*Heap*")
-//////        exclude("it/unimi/dsi/fastutil/objects/*Object*Set*")
-//                    exclude("it/unimi/dsi/fastutil/objects/package-info*")
-//
-//                    exclude("it/unimi/dsi/fastutil/*Abstract*")
-//                    exclude("it/unimi/dsi/fastutil/*Array*")
-//                    exclude("it/unimi/dsi/fastutil/*Bi*")
-//                    exclude("it/unimi/dsi/fastutil/*Function*")
-//                    exclude("it/unimi/dsi/fastutil/*Hash*")
-//                    exclude("it/unimi/dsi/fastutil/*Queue*")
-//                    exclude("it/unimi/dsi/fastutil/*Pair*")
-//                    exclude("it/unimi/dsi/fastutil/*Math*")
-//                    exclude("it/unimi/dsi/fastutil/*Size*")
-//                    exclude("it/unimi/dsi/fastutil/*Stack*")
-//                    exclude("it/unimi/dsi/fastutil/*Swapper*")
-//                    exclude("it/unimi/dsi/fastutil/package-info*")
-//
-////                    relocate("it.unimi.dsi.fastutil", "dev.slne.fastutil")
-////                    it.unimi.dsi.fastutil.objects.ObjectSets
-//                    exclude("it/unimi/dsi/fastutil/object/ObjectSets")
-//                    exclude("it/unimi/dsi/fastutil/object/Object2BooleanMaps")
-//                }
-//            }
-//        }
-//    }
-//}
-
 description = "surf-api-velocity-server"
+
+kapt {
+    keepJavacAnnotationProcessors = true
+}


### PR DESCRIPTION
This pull request includes several changes aimed at improving the build configuration and updating dependencies. The most important changes include removing an unnecessary profile from the `.idea/compiler.xml` file, updating the project version in `gradle.properties`, and adding a new plugin in the `build.gradle.kts` file.

Build configuration improvements:

* [`.idea/compiler.xml`](diffhunk://#diff-2bb695a627709c0ba8d2645880396ff81d5f9f7ce16b2577cd9df1ea6f3b04b5L49-L91): Removed the "Gradle Imported" profile, which included multiple unnecessary entries.
* [`surf-api-velocity/surf-api-velocity-server/build.gradle.kts`](diffhunk://#diff-6b487355d632f7ac27e4d63df2cb55e1666f6666bea2ed10d306b95dff0a689cR3): Added the `kotlin("kapt")` plugin to the `plugins` block and configured `kapt` to keep Java annotation processors. [[1]](diffhunk://#diff-6b487355d632f7ac27e4d63df2cb55e1666f6666bea2ed10d306b95dff0a689cR3) [[2]](diffhunk://#diff-6b487355d632f7ac27e4d63df2cb55e1666f6666bea2ed10d306b95dff0a689cL26-R33)

Dependency updates:

* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version from `1.21.4-2.8.0-SNAPSHOT` to `1.21.4-2.8.1-SNAPSHOT`.… 1.21.4-2.8.1-SNAPSHOT