### PR TITLE
feat: replace annotationProcessor with kapt for Velocity API integration

### DIFF
--- a/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
+++ b/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
@@ -16,7 +16,7 @@ dependencies {
     api(libs.commons.math4.core)
     api(libs.aide.reflection)
     runtimeOnly(libs.flogger.slf4j.backend)
-    annotationProcessor(libs.velocity.api)
+    kapt(libs.velocity.api)
 }
 
 tasks {


### PR DESCRIPTION
This pull request includes a change to the `build.gradle.kts` file in the `surf-api-velocity/surf-api-velocity-server` directory. The change modifies the dependency configuration for the `velocity.api` library.

Dependency configuration update:

* [`surf-api-velocity/surf-api-velocity-server/build.gradle.kts`](diffhunk://#diff-6b487355d632f7ac27e4d63df2cb55e1666f6666bea2ed10d306b95dff0a689cL19-R19): Changed the annotation processor configuration from `annotationProcessor` to `kapt` for the `velocity.api` library.