### PR TITLE
feat: add PlayerLookupService for Minecraft player information retrieval

### DIFF
--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -4186,6 +4186,23 @@ public final class dev/slne/surf/surfapi/core/api/reflection/SurfReflectionKt {
 	public static final fun getSurfReflection ()Ldev/slne/surf/surfapi/core/api/reflection/SurfReflection;
 }
 
+public final class dev/slne/surf/surfapi/core/api/service/PlayerLookupService {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/PlayerLookupService;
+	public final fun getUsername (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUuid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/slne/surf/surfapi/core/api/service/UUIDSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/UUIDSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/UUID;
+	public final fun fromString (Ljava/lang/String;)Ljava/util/UUID;
+	public final fun fromUUID (Ljava/util/UUID;)Ljava/lang/String;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/UUID;)V
+}
+
 public abstract interface class dev/slne/surf/surfapi/core/api/util/ByEnum {
 	public abstract fun value ()Ljava/lang/Object;
 }

--- a/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
+++ b/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
@@ -2939,6 +2939,23 @@ public final class dev/slne/surf/surfapi/core/api/reflection/SurfReflectionKt {
 	public static final fun getSurfReflection ()Ldev/slne/surf/surfapi/core/api/reflection/SurfReflection;
 }
 
+public final class dev/slne/surf/surfapi/core/api/service/PlayerLookupService {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/PlayerLookupService;
+	public final fun getUsername (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUuid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/slne/surf/surfapi/core/api/service/UUIDSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/UUIDSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/UUID;
+	public final fun fromString (Ljava/lang/String;)Ljava/util/UUID;
+	public final fun fromUUID (Ljava/util/UUID;)Ljava/lang/String;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/UUID;)V
+}
+
 public abstract interface class dev/slne/surf/surfapi/core/api/util/ByEnum {
 	public abstract fun value ()Ljava/lang/Object;
 }

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/service/PlayerLookupService.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/service/PlayerLookupService.kt
@@ -1,0 +1,204 @@
+package dev.slne.surf.surfapi.core.api.service
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.sksamuel.aedile.core.asLoadingCache
+import com.sksamuel.aedile.core.expireAfterWrite
+import io.ktor.client.*
+import io.ktor.client.call.*
+import io.ktor.client.engine.okhttp.*
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.*
+import io.ktor.serialization.kotlinx.json.*
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.descriptors.PrimitiveKind
+import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.json.Json
+import java.util.*
+import kotlin.time.Duration.Companion.minutes
+
+/**
+ * Service for looking up Minecraft player information using their usernames or UUIDs.
+ *
+ * This service fetches player data primarily from Mojang's API with fallback support via Minetools.
+ * It employs caching to minimize API calls and enhance performance.
+ */
+object PlayerLookupService {
+
+    /** HTTP client configured for JSON requests and responses. */
+    private val client = HttpClient(OkHttp) {
+        install(ContentNegotiation) {
+            json(Json {
+                isLenient = true
+                encodeDefaults = true
+                ignoreUnknownKeys = true
+            })
+        }
+    }
+
+    /**
+     * Cache mapping usernames to UUIDs.
+     * Cached entries expire after 15 minutes.
+     */
+    private val nameToUuid = Caffeine.newBuilder()
+        .expireAfterWrite(15.minutes)
+        .asLoadingCache<String, UUID> {
+            try {
+                MinecraftApi.getUuid(it)
+            } catch (_: Exception) {
+                try {
+                    MinetoolsApi.getUuid(it)
+                } catch (_: Exception) {
+                    error("Failed to get UUID for $it")
+                }
+            }
+        }
+
+    /**
+     * Cache mapping UUIDs to usernames.
+     * Cached entries expire after 15 minutes.
+     */
+    private val uuidToName = Caffeine.newBuilder()
+        .expireAfterWrite(15.minutes)
+        .asLoadingCache<UUID, String> {
+            try {
+                MinecraftApi.getUsername(it)
+            } catch (_: Exception) {
+                try {
+                    MinetoolsApi.getUsername(it)
+                } catch (_: Exception) {
+                    error("Failed to get username for $it")
+                }
+            }
+        }
+
+    /**
+     * Retrieves the username corresponding to the provided UUID.
+     * @param uuid UUID of the player.
+     * @return Username associated with the UUID.
+     */
+    suspend fun getUsername(uuid: UUID): String = uuidToName.get(uuid)
+
+    /**
+     * Retrieves the UUID corresponding to the provided username.
+     * @param username Minecraft username.
+     * @return UUID associated with the username.
+     */
+    suspend fun getUuid(username: String): UUID = nameToUuid.get(username)
+
+    /**
+     * API interaction with Mojang's official endpoints.
+     */
+    private object MinecraftApi {
+        private const val BASE_URL = "https://api.mojang.com"
+
+        /**
+         * Fetches username from Mojang using UUID.
+         * @param uuid Player UUID.
+         * @return Username retrieved from Mojang.
+         */
+        suspend fun getUsername(uuid: UUID): String {
+            return client.get("$BASE_URL/user/profile/${UUIDSerializer.fromUUID(uuid)}")
+                .body<MojangResponse>()
+                .name
+        }
+
+        /**
+         * Fetches UUID from Mojang using username.
+         * @param username Player username.
+         * @return UUID retrieved from Mojang.
+         */
+        suspend fun getUuid(username: String): UUID {
+            return client.get("$BASE_URL/users/profiles/minecraft/$username")
+                .body<MojangResponse>()
+                .id
+        }
+    }
+
+    /**
+     * API interaction with Minetools as a fallback.
+     */
+    private object MinetoolsApi {
+        private const val BASE_URL = "https://api.minetools.eu"
+
+        /**
+         * Fetches username from Minetools using UUID.
+         * @param uuid Player UUID.
+         * @return Username retrieved from Minetools.
+         */
+        suspend fun getUsername(uuid: UUID): String {
+            return client.get("$BASE_URL/uuid/${UUIDSerializer.fromUUID(uuid)}")
+                .body<MinetoolsResponse>()
+                .name
+        }
+
+        /**
+         * Fetches UUID from Minetools using username.
+         * @param username Player username.
+         * @return UUID retrieved from Minetools.
+         */
+        suspend fun getUuid(username: String): UUID {
+            return client.get("$BASE_URL/uuid/$username")
+                .body<MinetoolsResponse>()
+                .id
+        }
+    }
+
+    /**
+     * Response format for Mojang's API.
+     * @property id Player UUID.
+     * @property name Player username.
+     */
+    @Serializable
+    private data class MojangResponse(
+        val id: UUIDAsString,
+        val name: String,
+    )
+
+    /**
+     * Response format for Minetools API.
+     * @property id Player UUID.
+     * @property name Player username.
+     */
+    @Serializable
+    private data class MinetoolsResponse(
+        val id: UUIDAsString,
+        val name: String,
+    )
+}
+
+/** Type alias for UUID represented as a serializable string. */
+typealias UUIDAsString = @Serializable(with = UUIDSerializer::class) UUID
+
+/**
+ * Custom serializer for UUID, converting to and from simplified string format without dashes.
+ */
+object UUIDSerializer : KSerializer<UUID> {
+    override val descriptor: SerialDescriptor =
+        PrimitiveSerialDescriptor("UUID", PrimitiveKind.STRING)
+
+    override fun serialize(encoder: Encoder, value: UUID) {
+        encoder.encodeString(fromUUID(value))
+    }
+
+    override fun deserialize(decoder: Decoder): UUID {
+        return fromString(decoder.decodeString())
+    }
+
+    /** Converts UUID to string format without dashes. */
+    fun fromUUID(value: UUID): String {
+        return value.toString().replace("-", "")
+    }
+
+    /** Converts simplified UUID string back to standard UUID format. */
+    fun fromString(input: String): UUID {
+        return UUID.fromString(
+            input.replaceFirst(
+                "(\\w{8})(\\w{4})(\\w{4})(\\w{4})(\\w{12})".toRegex(), "$1-$2-$3-$4-$5"
+            )
+        )
+    }
+}

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/service/PlayerLookupService.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/service/PlayerLookupService.kt
@@ -45,14 +45,14 @@ object PlayerLookupService {
      */
     private val nameToUuid = Caffeine.newBuilder()
         .expireAfterWrite(15.minutes)
-        .asLoadingCache<String, UUID> {
+        .asLoadingCache<String, UUID?> {
             try {
                 MinecraftApi.getUuid(it)
             } catch (_: Exception) {
                 try {
                     MinetoolsApi.getUuid(it)
                 } catch (_: Exception) {
-                    error("Failed to get UUID for $it")
+                    null
                 }
             }
         }
@@ -63,14 +63,14 @@ object PlayerLookupService {
      */
     private val uuidToName = Caffeine.newBuilder()
         .expireAfterWrite(15.minutes)
-        .asLoadingCache<UUID, String> {
+        .asLoadingCache<UUID, String?> {
             try {
                 MinecraftApi.getUsername(it)
             } catch (_: Exception) {
                 try {
                     MinetoolsApi.getUsername(it)
                 } catch (_: Exception) {
-                    error("Failed to get username for $it")
+                    null
                 }
             }
         }
@@ -78,16 +78,16 @@ object PlayerLookupService {
     /**
      * Retrieves the username corresponding to the provided UUID.
      * @param uuid UUID of the player.
-     * @return Username associated with the UUID.
+     * @return Username associated with the UUID or null if not found.
      */
-    suspend fun getUsername(uuid: UUID): String = uuidToName.get(uuid)
+    suspend fun getUsername(uuid: UUID): String? = uuidToName.get(uuid)
 
     /**
      * Retrieves the UUID corresponding to the provided username.
      * @param username Minecraft username.
-     * @return UUID associated with the username.
+     * @return UUID associated with the username or null if not found.
      */
-    suspend fun getUuid(username: String): UUID = nameToUuid.get(username)
+    suspend fun getUuid(username: String): UUID? = nameToUuid.get(username)
 
     /**
      * API interaction with Mojang's official endpoints.

--- a/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
+++ b/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
@@ -3162,6 +3162,23 @@ public final class dev/slne/surf/surfapi/core/api/reflection/SurfReflectionKt {
 	public static final fun getSurfReflection ()Ldev/slne/surf/surfapi/core/api/reflection/SurfReflection;
 }
 
+public final class dev/slne/surf/surfapi/core/api/service/PlayerLookupService {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/PlayerLookupService;
+	public final fun getUsername (Ljava/util/UUID;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public final fun getUuid (Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class dev/slne/surf/surfapi/core/api/service/UUIDSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Ldev/slne/surf/surfapi/core/api/service/UUIDSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/UUID;
+	public final fun fromString (Ljava/lang/String;)Ljava/util/UUID;
+	public final fun fromUUID (Ljava/util/UUID;)Ljava/lang/String;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/UUID;)V
+}
+
 public abstract interface class dev/slne/surf/surfapi/core/api/util/ByEnum {
 	public abstract fun value ()Ljava/lang/Object;
 }


### PR DESCRIPTION
This pull request introduces a new service for player lookup and a custom serializer for UUIDs across multiple modules. The main changes include the addition of the `PlayerLookupService` and `UUIDSerializer` classes, along with their respective methods and functionalities.

### New Service and Serializer:

* **PlayerLookupService**:
  * Added a new service for looking up Minecraft player information using usernames or UUIDs.
  * Includes methods for fetching player data from Mojang's API with fallback support via Minetools.
  * Implements caching to minimize API calls and enhance performance. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR4189-R4205) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R2942-R2958) [[3]](diffhunk://#diff-cfabe3feaa79fe3574d3bd2351f48434d7fb42e0ab926ec7fd9b3861f1301279R3165-R3181) [[4]](diffhunk://#diff-f19b134007490932d2567ca6e34dad7654ea72bf60af6ecbfe457d2182fb1c64R1-R204)

* **UUIDSerializer**:
  * Added a custom serializer for UUIDs, converting to and from a simplified string format without dashes.
  * Includes methods for serializing and deserializing UUIDs, as well as converting between string and UUID formats. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR4189-R4205) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R2942-R2958) [[3]](diffhunk://#diff-cfabe3feaa79fe3574d3bd2351f48434d7fb42e0ab926ec7fd9b3861f1301279R3165-R3181) [[4]](diffhunk://#diff-f19b134007490932d2567ca6e34dad7654ea72bf60af6ecbfe457d2182fb1c64R1-R204)

These changes enhance the functionality of the API by providing efficient player lookup capabilities and a custom serializer for UUIDs, improving both performance and usability.