### PR TITLE
Fix/player lookup service

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -10,5 +10,6 @@ dependencies {
     implementation(libs.kotlin.gradle.plugin)
     implementation(libs.shadow.gradle.plugin)
     implementation(libs.ksp.gradle.plugin)
+    implementation(libs.kotlin.serialization)
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
 }

--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `maven-publish`
 
     kotlin("jvm")
+    kotlin("plugin.serialization")
 
     id("com.google.devtools.ksp")
     id("com.gradleup.shadow")

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.9.0-SNAPSHOT
+version=1.21.4-2.9.1-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -12,7 +12,7 @@ plugins {
     `kotlin-dsl`
 
     id("com.gradle.plugin-publish") version "1.3.0"
-    alias(libs.plugins.kotlin.serialization)
+    kotlin("plugin.serialization")
 //    alias(libs.plugins.maven.repo.auth)
 }
 

--- a/surf-api-modern-generator/build.gradle.kts
+++ b/surf-api-modern-generator/build.gradle.kts
@@ -11,8 +11,6 @@ import kotlin.io.path.*
 
 plugins {
     `core-convention`
-
-    kotlin("plugin.serialization") version libs.versions.kotlinVersion
 }
 
 dependencies {


### PR DESCRIPTION
This pull request introduces several changes related to the Kotlin serialization plugin and version updates. The most important changes include adding the Kotlin serialization plugin to various build files and updating the project version.

### Kotlin Serialization Plugin Integration:
* [`buildSrc/build.gradle.kts`](diffhunk://#diff-7b5c40eb5522b5216cfe8c75612e579a8db0daee9ded80df9ce6a56e8361a962R13): Added `implementation(libs.kotlin.serialization)` to the dependencies.
* [`buildSrc/src/main/kotlin/core-convention.gradle.kts`](diffhunk://#diff-5a51cb93c1412ae49a475aec86c766d8248bf186e435b09da9e5ec11f674c776R12): Added `kotlin("plugin.serialization")` to the plugins section.
* [`surf-api-gradle-plugin/build.gradle.kts`](diffhunk://#diff-2e36ad9dcce88f8b5727df509328b34dae36f5121e3c833790b233c87a79c54eL15-R15): Replaced `alias(libs.plugins.kotlin.serialization)` with `kotlin("plugin.serialization")` in the plugins section.
* [`surf-api-modern-generator/build.gradle.kts`](diffhunk://#diff-053e26b72938573a83a5b58c83d84b998f3ed56689a8f04513d90411af16733eL14-L15): Removed `kotlin("plugin.serialization")` from the plugins section.

### Version Update:
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version from `1.21.4-2.9.0-SNAPSHOT` to `1.21.4-2.9.1-SNAPSHOT`.