### PR TITLE
Feat/add minemessage arg

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.9.1-SNAPSHOT
+version=1.21.4-2.10.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -1026,6 +1026,15 @@ public final class dev/slne/surf/surfapi/bukkit/api/collections/LazyIntList {
 	public final fun set (II)V
 }
 
+public class dev/slne/surf/surfapi/bukkit/api/command/args/MiniMessageArgument : dev/jorel/commandapi/arguments/CustomArgument {
+	public fun <init> (Ljava/lang/String;)V
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/command/args/MiniMessageArgumentKt {
+	public static final fun miniMessageArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static synthetic fun miniMessageArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
+}
+
 public final class dev/slne/surf/surfapi/bukkit/api/event/Listener_extensionKt {
 	public static final fun listen (Lorg/bukkit/plugin/Plugin;Lkotlin/reflect/KClass;Lorg/bukkit/event/EventPriority;ZZLkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/bukkit/api/event/SingleListener;
 	public static synthetic fun listen$default (Lorg/bukkit/plugin/Plugin;Lkotlin/reflect/KClass;Lorg/bukkit/event/EventPriority;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/slne/surf/surfapi/bukkit/api/event/SingleListener;

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/command/args/MiniMessageArgument.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/command/args/MiniMessageArgument.kt
@@ -1,0 +1,36 @@
+package dev.slne.surf.surfapi.bukkit.api.command.args
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.TextArgument
+import dev.slne.surf.surfapi.core.api.command.builder.CommandExceptionBuilder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.ParsingException
+
+open class MiniMessageArgument(nodeName: String) : CustomArgument<Component, String>(
+    TextArgument(nodeName),
+    { info ->
+        val raw = info.currentInput
+
+        try {
+            MiniMessage.miniMessage().deserialize(raw)
+        } catch (e: ParsingException) {
+            throw CustomArgumentException.fromAdventureComponent(
+                CommandExceptionBuilder(
+                    e.detailMessage(),
+                    e.originalText(),
+                    e.endIndex()
+                ).build()
+            )
+        }
+    }
+)
+
+inline fun CommandAPICommand.miniMessageArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {},
+): CommandAPICommand =
+    withArguments(MiniMessageArgument(nodeName).setOptional(optional).apply(block))

--- a/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
+++ b/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
@@ -4600,6 +4600,19 @@ public final class dev/slne/surf/surfapi/velocity/api/SurfVelocityApiKt {
 	public static final fun getSurfVelocityApi ()Ldev/slne/surf/surfapi/velocity/api/SurfVelocityApi;
 }
 
+public class dev/slne/surf/surfapi/velocity/api/command/args/MiniMessageArgument : dev/jorel/commandapi/arguments/Argument {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getArgumentType ()Ldev/jorel/commandapi/arguments/CommandAPIArgumentType;
+	public fun getPrimitiveType ()Ljava/lang/Class;
+	public synthetic fun parseArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Ldev/jorel/commandapi/executors/CommandArguments;)Ljava/lang/Object;
+	public fun parseArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Ldev/jorel/commandapi/executors/CommandArguments;)Lnet/kyori/adventure/text/Component;
+}
+
+public final class dev/slne/surf/surfapi/velocity/api/command/args/MiniMessageArgumentKt {
+	public static final fun miniMessageArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static synthetic fun miniMessageArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
+}
+
 public final class io/ktor/client/HttpClient : java/io/Closeable, kotlinx/coroutines/CoroutineScope {
 	public fun <init> (Lio/ktor/client/engine/HttpClientEngine;Lio/ktor/client/HttpClientConfig;)V
 	public synthetic fun <init> (Lio/ktor/client/engine/HttpClientEngine;Lio/ktor/client/HttpClientConfig;ILkotlin/jvm/internal/DefaultConstructorMarker;)V

--- a/surf-api-velocity/surf-api-velocity-api/src/main/kotlin/dev/slne/surf/surfapi/velocity/api/command/args/MiniMessageArgument.kt
+++ b/surf-api-velocity/surf-api-velocity-api/src/main/kotlin/dev/slne/surf/surfapi/velocity/api/command/args/MiniMessageArgument.kt
@@ -1,0 +1,54 @@
+package dev.slne.surf.surfapi.velocity.api.command.args
+
+import com.mojang.brigadier.arguments.StringArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType
+import com.velocitypowered.api.command.VelocityBrigadierMessage
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.CommandAPIArgumentType
+import dev.jorel.commandapi.executors.CommandArguments
+import dev.slne.surf.surfapi.core.api.command.builder.CommandExceptionBuilder
+import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.minimessage.MiniMessage
+import net.kyori.adventure.text.minimessage.ParsingException
+
+open class MiniMessageArgument(nodeName: String) :
+    Argument<Component>(nodeName, StringArgumentType.string()) {
+    override fun getPrimitiveType(): Class<Component> {
+        return Component::class.java
+    }
+
+    override fun getArgumentType(): CommandAPIArgumentType? {
+        return CommandAPIArgumentType.PRIMITIVE_TEXT
+    }
+
+    override fun <Source : Any?> parseArgument(
+        cmdCtx: CommandContext<Source>,
+        key: String,
+        previousArgs: CommandArguments,
+    ): Component {
+        val raw = StringArgumentType.getString(cmdCtx, key)
+
+        try {
+            return MiniMessage.miniMessage().deserialize(raw)
+        } catch (e: ParsingException) {
+            throw SimpleCommandExceptionType(
+                VelocityBrigadierMessage.tooltip(
+                    CommandExceptionBuilder(
+                        e.detailMessage(),
+                        e.originalText(),
+                        e.endIndex()
+                    ).build()
+                )
+            ).create()
+        }
+    }
+}
+
+inline fun CommandAPICommand.miniMessageArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {},
+): CommandAPICommand =
+    withArguments(MiniMessageArgument(nodeName).setOptional(optional).apply(block))


### PR DESCRIPTION
This pull request includes several changes to add support for `MiniMessageArgument` in both the Bukkit and Velocity APIs, and updates the project version.

### Version Update:
* Updated the project version in `gradle.properties` from `1.21.4-2.9.1-SNAPSHOT` to `1.21.4-2.10.0-SNAPSHOT`.

### Bukkit API Enhancements:
* Added `MiniMessageArgument` class and related functions to the `surf-api-bukkit` module. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR1029-R1037) [[2]](diffhunk://#diff-180e1326370a150855b0b0c0a46eb68502f5491960b06bfe07a8525ade533099R1-R36)

### Velocity API Enhancements:
* Added `MiniMessageArgument` class and related functions to the `surf-api-velocity` module. [[1]](diffhunk://#diff-cfabe3feaa79fe3574d3bd2351f48434d7fb42e0ab926ec7fd9b3861f1301279R4603-R4615) [[2]](diffhunk://#diff-191a9b8df768eccd5d074b706f7a49e7c67897e6a9de56d16399021bcf0c91b5R1-R54)