### PR TITLE
Fix/inline component builder methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.10.0-SNAPSHOT
+version=1.21.4-2.11.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -3844,11 +3844,13 @@ public final class dev/slne/surf/surfapi/core/api/messages/adventure/Title_exten
 public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder : net/kyori/adventure/text/TextComponent$Builder {
 	public static final field Companion Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$Companion;
 	public abstract fun append (Ljava/lang/Iterable;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun append (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendCollection (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendCollectionNewLine (Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendDisconnectFooterTryAgainLater (Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -3858,7 +3860,11 @@ public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/
 	public abstract fun appendKickDisconnectMessage (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendMap (Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendNewPrefixedLine ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLine (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendNewline ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewline (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewlineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendPrefix ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendSpace ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendTime-gRj5Bb8 (JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -3977,6 +3983,8 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$DefaultImpls {
+	public static fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendCollection (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendCollectionNewLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendCollectionNewLine$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -3990,6 +3998,10 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun appendMap (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendMap$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewlineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendPrefix (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendTime-gRj5Bb8 (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendTime-gRj5Bb8$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -4079,12 +4091,6 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;J)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/String;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-}
-
-public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilderKt {
-	public static final fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/bundle/SurfMessageBundle {

--- a/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
+++ b/surf-api-core/surf-api-core-api/api/surf-api-core-api.api
@@ -2588,11 +2588,13 @@ public final class dev/slne/surf/surfapi/core/api/messages/adventure/Title_exten
 public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder : net/kyori/adventure/text/TextComponent$Builder {
 	public static final field Companion Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$Companion;
 	public abstract fun append (Ljava/lang/Iterable;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun append (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendCollection (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendCollectionNewLine (Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendDisconnectFooterTryAgainLater (Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2602,7 +2604,11 @@ public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/
 	public abstract fun appendKickDisconnectMessage (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendMap (Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendNewPrefixedLine ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLine (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendNewline ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewline (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewlineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendPrefix ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendSpace ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendTime-gRj5Bb8 (JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2721,6 +2727,8 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$DefaultImpls {
+	public static fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendCollection (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendCollectionNewLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendCollectionNewLine$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2734,6 +2742,10 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun appendMap (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendMap$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewlineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendPrefix (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendTime-gRj5Bb8 (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendTime-gRj5Bb8$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2823,12 +2835,6 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;J)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/String;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-}
-
-public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilderKt {
-	public static final fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/bundle/SurfMessageBundle {

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder.kt
@@ -46,6 +46,24 @@ interface SurfComponentBuilder : TextComponent.Builder {
     fun appendPrefix() = append(PREFIX)
     fun appendNewPrefixedLine() = appendNewline().appendPrefix()
 
+    fun append(block: SurfComponentBuilder.() -> Unit): SurfComponentBuilder =
+        append(SurfComponentBuilder(block))
+
+    suspend fun appendAsync(block: suspend SurfComponentBuilder.() -> Unit): SurfComponentBuilder =
+        append(SurfComponentBuilder { block() })
+
+    fun appendNewline(block: SurfComponentBuilder.() -> Unit) =
+        appendNewline().append(block)
+
+    suspend fun appendNewlineAsync(block: suspend SurfComponentBuilder.() -> Unit) =
+        appendNewline().appendAsync(block)
+
+    fun appendNewPrefixedLine(block: SurfComponentBuilder.() -> Unit) =
+        appendNewPrefixedLine().append(block)
+
+    suspend fun appendNewPrefixedLineAsync(block: suspend SurfComponentBuilder.() -> Unit) =
+        appendNewPrefixedLine().appendAsync(block)
+
     fun text(text: String, color: TextColor? = null) = append(Component.text(text, color))
     fun text(boolean: Boolean, color: TextColor? = null) = append(Component.text(boolean, color))
     fun text(char: Char, color: TextColor? = null) = append(Component.text(char, color))
@@ -241,12 +259,3 @@ interface SurfComponentBuilder : TextComponent.Builder {
     override fun shadowColor(argb: ARGBLike?): SurfComponentBuilder
     override fun shadowColorIfAbsent(argb: ARGBLike?): SurfComponentBuilder
 }
-
-inline fun SurfComponentBuilder.append(block: SurfComponentBuilder.() -> Unit) =
-    append(SurfComponentBuilder(block))
-
-inline fun SurfComponentBuilder.appendNewline(block: SurfComponentBuilder.() -> Unit) =
-    appendNewline().append(block)
-
-inline fun SurfComponentBuilder.appendNewPrefixedLine(block: SurfComponentBuilder.() -> Unit) =
-    appendNewPrefixedLine().append(block)

--- a/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
+++ b/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
@@ -2811,11 +2811,13 @@ public final class dev/slne/surf/surfapi/core/api/messages/adventure/Title_exten
 public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder : net/kyori/adventure/text/TextComponent$Builder {
 	public static final field Companion Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$Companion;
 	public abstract fun append (Ljava/lang/Iterable;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun append (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append (Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun append ([Lnet/kyori/adventure/text/ComponentLike;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendCollection (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendCollectionNewLine (Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendDisconnectFooterTryAgainLater (Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2825,7 +2827,11 @@ public abstract interface class dev/slne/surf/surfapi/core/api/messages/builder/
 	public abstract fun appendKickDisconnectMessage (Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendMap (Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendNewPrefixedLine ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLine (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewPrefixedLineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendNewline ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewline (Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public abstract fun appendNewlineAsync (Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun appendPrefix ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendSpace ()Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public abstract fun appendTime-gRj5Bb8 (JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2944,6 +2950,8 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder$DefaultImpls {
+	public static fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendCollection (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendCollectionNewLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendCollectionNewLine$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/Iterable;Lnet/kyori/adventure/text/Component;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -2957,6 +2965,10 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun appendMap (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendMap$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/util/Map;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function1;Lnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewPrefixedLineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
+	public static fun appendNewlineAsync (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static fun appendPrefix (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun appendTime-gRj5Bb8 (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static synthetic fun appendTime-gRj5Bb8$default (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;JZZLnet/kyori/adventure/text/Component;Lnet/kyori/adventure/text/format/TextColor;ILjava/lang/Object;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
@@ -3046,12 +3058,6 @@ public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponent
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;J)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Ljava/lang/String;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 	public static fun warning (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Z)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-}
-
-public final class dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilderKt {
-	public static final fun append (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewPrefixedLine (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
-	public static final fun appendNewline (Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;Lkotlin/jvm/functions/Function1;)Ldev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder;
 }
 
 public final class dev/slne/surf/surfapi/core/api/messages/bundle/SurfMessageBundle {


### PR DESCRIPTION
This pull request includes several changes to the `SurfComponentBuilder` interface and related classes across multiple modules. The changes primarily focus on adding new asynchronous methods and updating the version in the `gradle.properties` file.

### Version Update:
* Updated the project version from `1.21.4-2.10.0-SNAPSHOT` to `1.21.4-2.11.0-SNAPSHOT` in `gradle.properties`.

### New Methods in `SurfComponentBuilder` Interface:
* Added new `append` and `appendAsync` methods that accept `Function1` and `Function2` parameters respectively. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR3847-R3853) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R2591-R2597) [[3]](diffhunk://#diff-cfabe3feaa79fe3574d3bd2351f48434d7fb42e0ab926ec7fd9b3861f1301279R2814-R2820)
* Introduced new `appendNewPrefixedLine`, `appendNewPrefixedLineAsync`, `appendNewline`, and `appendNewlineAsync` methods with `Function1` and `Function2` parameters. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR3863-R3867) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R2607-R2611)

### Default Implementations:
* Added default implementations for the new methods in `SurfComponentBuilder$DefaultImpls` class. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR3986-R3987) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0R2730-R2731)
* Removed redundant methods from `SurfComponentBuilderKt` class. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL4084-L4089) [[2]](diffhunk://#diff-18f09fc57353fc0371c0ac98a8ccc5a2b8d7b5b6e4420b0387c55543d175efe0L2828-L2833)

### Kotlin File Updates:
* Updated `SurfComponentBuilder.kt` to include new methods for appending components and their asynchronous counterparts. [[1]](diffhunk://#diff-e924b0924b11202d4692ea9ece36747ebde908d0b508979428e058d0705b9cfcR49-R66) [[2]](diffhunk://#diff-e924b0924b11202d4692ea9ece36747ebde908d0b508979428e058d0705b9cfcL244-L252)