### PR TITLE
fix: update Command API version and adjust related properties in build configuration

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.11.0-SNAPSHOT
+version=1.21.4-2.12.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,7 @@ kotlinx-serialization = "1.8.0"
 packetevents = "2.7.0"
 
 # Command API
-commandapi = "9.7.0"
-commandapi-snapshot = "9.6.2-SNAPSHOT"
+commandapi = "10.0.0"
 
 # Scoreboard Library
 scoreboard-library = "2.2.2"
@@ -86,8 +85,8 @@ packetevents-netty-common = { module = "com.github.retrooper:packetevents-netty-
 commandapi-bukkit = { module = "dev.jorel:commandapi-bukkit-plugin", version.ref = "commandapi" }
 commandapi-bukkit-kotlin = { module = "dev.jorel:commandapi-bukkit-kotlin", version.ref = "commandapi" }
 commandapi-core = { module = "dev.jorel:commandapi-core", version.ref = "commandapi" }
-commandapi-velocity = { module = "dev.jorel:commandapi-velocity-core", version.ref = "commandapi-snapshot" }
-commandapi-velocity-kotlin = { module = "dev.jorel:commandapi-velocity-kotlin", version.ref = "commandapi-snapshot" }
+commandapi-velocity = { module = "dev.jorel:commandapi-velocity-core", version.ref = "commandapi" }
+commandapi-velocity-kotlin = { module = "dev.jorel:commandapi-velocity-kotlin", version.ref = "commandapi" }
 
 # Scoreboard Library
 scoreboard-library-api = { module = "net.megavex:scoreboard-library-api", version.ref = "scoreboard-library" }

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -540,6 +540,8 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static final fun argument (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun argument$default (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun arguments (Ldev/jorel/commandapi/CommandAPICommand;[Ldev/jorel/commandapi/arguments/Argument;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static final fun asyncOfflinePlayerArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static synthetic fun asyncOfflinePlayerArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun axisArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun axisArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun biomeArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -557,11 +559,9 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static final fun chatComponentArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun chatComponentArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun commandAPICommand (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static final fun commandAPICommand (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandAPICommand (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandAPICommand (Ljava/lang/String;Lorg/bukkit/plugin/java/JavaPlugin;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Lorg/bukkit/plugin/java/JavaPlugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun commandArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -610,12 +610,8 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static synthetic fun lootTableArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun mathOperationArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun mathOperationArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun namespacedKeyArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun namespacedKeyArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun nbtCompoundArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -637,8 +633,6 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static synthetic fun potionEffectArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun recipeArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun recipeArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun requirement (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun rotationArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun rotationArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun scoreHolderArgumentMultiple (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -694,6 +688,10 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static final fun argument (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun argument$default (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun argument$default (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
+	public static final fun asyncOfflinePlayerArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
+	public static final fun asyncOfflinePlayerArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
+	public static synthetic fun asyncOfflinePlayerArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
+	public static synthetic fun asyncOfflinePlayerArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun axisArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun axisArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun axisArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
@@ -731,11 +729,9 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static synthetic fun commandArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun commandArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun commandTree (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static final fun commandTree (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandTree (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandTree (Ljava/lang/String;Lorg/bukkit/plugin/java/JavaPlugin;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun commandTree$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun commandTree$default (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandTree$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandTree$default (Ljava/lang/String;Lorg/bukkit/plugin/java/JavaPlugin;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun doubleArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;DDZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
@@ -826,18 +822,10 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static final fun mathOperationArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun mathOperationArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun mathOperationArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun namespacedKeyArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun namespacedKeyArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun namespacedKeyArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
@@ -884,10 +872,6 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static final fun recipeArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun recipeArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun recipeArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun requirement (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun requirement (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun rotationArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun rotationArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun rotationArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -100,7 +100,7 @@ val generateConstants by tasks.registering {
     inputs.property("libs.velocity.api", libs.velocity.api.get().toString())
     inputs.property("libs.auto.service.annotations", libs.auto.service.annotations.get().toString())
     inputs.property("libs.auto.service", libs.auto.service.asProvider().get().toString())
-    inputs.property("libs.versions.commandapi", libs.versions.commandapi.asProvider().get().toString())
+    inputs.property("libs.versions.commandapi", libs.versions.commandapi.get().toString())
     inputs.property("libs.versions.placeholder.api", libs.versions.placeholder.api.get().toString())
     inputs.property("version", rootProject.findProperty("version") as String)
     outputs.dir(constantsOutputDir)
@@ -122,7 +122,7 @@ val generateConstants by tasks.registering {
             |    const val MINECRAFT_VERSION = "$mcVersion"
             |    const val SURF_API_VERSION = "$mcVersion+"
             |    
-            |    const val COMMAND_API_VERSION = "${libs.versions.commandapi.asProvider().get()}"
+            |    const val COMMAND_API_VERSION = "${libs.versions.commandapi.get()}"
             |    const val PLACEHOLDER_API_VERSION = "${libs.versions.placeholder.api.get()}"
             |    
             |    const val SURF_API_FULL_VERSION = "${rootProject.findProperty("version") as String}"

--- a/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
+++ b/surf-api-velocity/surf-api-velocity-api/api/surf-api-velocity-api.api
@@ -620,10 +620,8 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static final fun booleanArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun booleanArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun commandAPICommand (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static final fun commandAPICommand (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandAPICommand (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandAPICommand$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun doubleArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;DDZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun doubleArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;DDZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -639,17 +637,11 @@ public final class dev/jorel/commandapi/kotlindsl/CommandAPICommandDSLKt {
 	public static synthetic fun literalArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun longArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;JJZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun longArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;JJZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandAPICommand;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandAPICommand;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun optionalArgument (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun optionalArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun optionalArguments (Ldev/jorel/commandapi/CommandAPICommand;[Ldev/jorel/commandapi/arguments/Argument;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static final fun requirement (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun stringArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static synthetic fun stringArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
 	public static final fun subcommand (Ldev/jorel/commandapi/CommandAPICommand;Ldev/jorel/commandapi/CommandAPICommand;)Ldev/jorel/commandapi/CommandAPICommand;
@@ -671,10 +663,8 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static synthetic fun booleanArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun booleanArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun commandTree (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
-	public static final fun commandTree (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)V
 	public static final fun commandTree (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public static synthetic fun commandTree$default (Ljava/lang/String;Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
-	public static synthetic fun commandTree$default (Ljava/lang/String;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static synthetic fun commandTree$default (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)V
 	public static final fun doubleArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;DDZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun doubleArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;DDZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
@@ -704,26 +694,14 @@ public final class dev/jorel/commandapi/kotlindsl/CommandTreeDSLKt {
 	public static final fun longArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;JJZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun longArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;JJZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun longArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;JJZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/CommandTree;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun multiLiteralArgument (Ldev/jorel/commandapi/arguments/Argument;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/CommandTree;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;Ljava/util/List;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun multiLiteralArgument$default (Ldev/jorel/commandapi/arguments/Argument;[Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun optionalArgument (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun optionalArgument (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun optionalArgument$default (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
 	public static synthetic fun optionalArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
-	public static final fun requirement (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
-	public static final fun requirement (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/CommandTree;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
-	public static synthetic fun requirement$default (Ldev/jorel/commandapi/arguments/Argument;Ldev/jorel/commandapi/arguments/Argument;Ljava/util/function/Predicate;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
 	public static final fun stringArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
 	public static final fun stringArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
 	public static synthetic fun stringArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;


### PR DESCRIPTION
This pull request includes various updates and improvements to the project, focusing on dependency updates, code cleanup, and new functionality additions. The most important changes include updating library versions, removing deprecated methods, and adding new methods for handling asynchronous operations.

Dependency updates:
* Updated `commandapi` version from `9.7.0` to `10.0.0` in `gradle/libs.versions.toml`.
* Updated `version` in `gradle.properties` from `1.21.4-2.11.0-SNAPSHOT` to `1.21.4-2.12.0-SNAPSHOT`.

Code cleanup:
* Removed deprecated methods and synthetic functions related to `multiLiteralArgument` and `requirement` in `surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL613-L618) [[2]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL640-L641) [[3]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL829-L840) [[4]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dL887-L890)
* Removed the `CommitMessageInspectionProfile` component from `.idea/vcs.xml`.

New functionality:
* Added new methods for handling `asyncOfflinePlayerArgument` in `surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`. [[1]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR543-R544) [[2]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR691-R694)
* Updated property access methods in `surf-api-gradle-plugin/build.gradle.kts` to use `.get()` instead of `.asProvider().get()`. [[1]](diffhunk://#diff-2e36ad9dcce88f8b5727df509328b34dae36f5121e3c833790b233c87a79c54eL103-R103) [[2]](diffhunk://#diff-2e36ad9dcce88f8b5727df509328b34dae36f5121e3c833790b233c87a79c54eL125-R125)