### PR TITLE
Feat/implement clientbound disconnect packet

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="CommitMessageInspectionProfile">
+    <profile version="1.0">
+      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
+      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
+    </profile>
+  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,5 +9,5 @@ javaVersion=21
 mcVersion=1.21.4
 
 group=dev.slne.surf
-version=1.21.4-2.12.0-SNAPSHOT
+version=1.21.4-2.13.0-SNAPSHOT
 relocationPrefix=dev.slne.surf.surfapi.libs

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -1500,6 +1500,10 @@ public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/listener/pa
 	public abstract fun getPacketClass ()Ljava/lang/Class;
 }
 
+public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/DisconnectPacket : dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/NmsClientboundPacket {
+	public abstract fun getReason ()Lnet/kyori/adventure/text/Component;
+}
+
 public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/NmsClientboundPacket : dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/NmsPacket {
 }
 

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/DisconnectPacket.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/DisconnectPacket.kt
@@ -1,0 +1,9 @@
+package dev.slne.surf.surfapi.bukkit.api.nms.listener.packets.clientbound
+
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import net.kyori.adventure.text.Component
+
+@NmsUseWithCaution
+interface DisconnectPacket : NmsClientboundPacket {
+    val reason: Component
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/PacketRegistry.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/PacketRegistry.kt
@@ -3,12 +3,18 @@ package dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets
 import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.bukkit.api.nms.listener.packets.clientbound.NmsClientboundPacket
 import dev.slne.surf.surfapi.bukkit.api.nms.listener.packets.serverbound.NmsServerboundPacket
+import dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.clientbound.ClientboundDisconnectPacketImpl
 import dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.serverbound.CommandSuggestionPacketImpl
 import dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.serverbound.RenameItemPacketImpl
 import dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.serverbound.SignUpdatePacketImpl
 import dev.slne.surf.surfapi.core.api.util.mutableObject2ObjectMapOf
 import net.minecraft.network.protocol.Packet
-import net.minecraft.network.protocol.game.*
+import net.minecraft.network.protocol.common.ClientCommonPacketListener
+import net.minecraft.network.protocol.common.ClientboundDisconnectPacket
+import net.minecraft.network.protocol.game.ServerGamePacketListener
+import net.minecraft.network.protocol.game.ServerboundCommandSuggestionPacket
+import net.minecraft.network.protocol.game.ServerboundRenameItemPacket
+import net.minecraft.network.protocol.game.ServerboundSignUpdatePacket
 import kotlin.reflect.KClass
 
 @OptIn(NmsUseWithCaution::class)
@@ -20,9 +26,13 @@ object PacketRegistry {
 
     init {
         // @formatter:off
+        // Serverbound packets
         registerServerboundPacket(ServerboundSignUpdatePacket::class) { SignUpdatePacketImpl(it) }
         registerServerboundPacket(ServerboundRenameItemPacket::class) { RenameItemPacketImpl(it) }
         registerServerboundPacket(ServerboundCommandSuggestionPacket::class) { CommandSuggestionPacketImpl(it) }
+
+        // Clientbound packets
+        registerClientboundPacket(ClientboundDisconnectPacket::class) { ClientboundDisconnectPacketImpl(it) }
         // @formatter:on
     }
 
@@ -38,9 +48,9 @@ object PacketRegistry {
         return factory?.create(packet)
     }
 
-    private fun <Nms : Packet<ClientGamePacketListener>, Api : NmsClientboundPacket> registerClientboundPacket(
+    private fun <Nms : Packet<ClientCommonPacketListener>, Api : NmsClientboundPacket> registerClientboundPacket(
         nms: KClass<Nms>,
-        factory: ClientboundPacketFactory<Nms, Api>
+        factory: ClientboundPacketFactory<Nms, Api>,
     ) {
         CLIENTBOUND_PACKETS.put(nms.java, factory)
     }

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/ClientboundDisconnectPacketImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/ClientboundDisconnectPacketImpl.kt
@@ -1,0 +1,12 @@
+package dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.clientbound
+
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.bukkit.api.nms.listener.packets.clientbound.DisconnectPacket
+import dev.slne.surf.surfapi.bukkit.server.nms.toBukkit
+import net.minecraft.network.protocol.common.ClientboundDisconnectPacket
+
+@NmsUseWithCaution
+class ClientboundDisconnectPacketImpl(nmsPacket: ClientboundDisconnectPacket) :
+    NmsClientboundPacketImpl<ClientboundDisconnectPacket>(nmsPacket), DisconnectPacket {
+    override val reason get() = nmsPacket.reason.toBukkit()
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/NmsClientboundPacketImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/NmsClientboundPacketImpl.kt
@@ -1,0 +1,10 @@
+package dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.clientbound
+
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.bukkit.server.impl.nms.listener.packets.NmsPacketImpl
+import net.minecraft.network.protocol.Packet
+import net.minecraft.network.protocol.common.ClientCommonPacketListener
+
+@NmsUseWithCaution
+abstract class NmsClientboundPacketImpl<Nms : Packet<ClientCommonPacketListener>>(nmsPacket: Nms) :
+    NmsPacketImpl<Nms, ClientCommonPacketListener>(nmsPacket)


### PR DESCRIPTION
This pull request introduces several changes to the `surf-api-bukkit` project, including the addition of a new `DisconnectPacket` interface and its implementation, as well as updates to the packet registry to support this new packet type. Additionally, there are updates to the project configuration and versioning.

New feature additions and updates:

* [`surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api`](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR1503-R1506): Added a new `DisconnectPacket` interface to handle client-bound disconnect packets.
* [`surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/listener/packets/clientbound/DisconnectPacket.kt`](diffhunk://#diff-99c87a0b1390aae05dd6be350a7a6ed8414ae7b2c44a30075e706cc546be28d0R1-R9): Implemented the `DisconnectPacket` interface with a `reason` property.

Packet registry updates:

* [`surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/PacketRegistry.kt`](diffhunk://#diff-39e0f959493fb000e7df0b0833d94b440edea0f7b136af68251c3ffffd49f0c7R6-R17): Updated the packet registry to include the new `ClientboundDisconnectPacket` and its implementation. [[1]](diffhunk://#diff-39e0f959493fb000e7df0b0833d94b440edea0f7b136af68251c3ffffd49f0c7R6-R17) [[2]](diffhunk://#diff-39e0f959493fb000e7df0b0833d94b440edea0f7b136af68251c3ffffd49f0c7R29-R35) [[3]](diffhunk://#diff-39e0f959493fb000e7df0b0833d94b440edea0f7b136af68251c3ffffd49f0c7L41-R53)
* [`surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/ClientboundDisconnectPacketImpl.kt`](diffhunk://#diff-b2fad513c82a18cbebda1646a6b58da89824ef97b720f2e73cd57540ba5333d5R1-R12): Added the implementation for the `ClientboundDisconnectPacketImpl` class.
* [`surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/listener/packets/clientbound/NmsClientboundPacketImpl.kt`](diffhunk://#diff-ade9f2209ff1ad616ddd153762225ed59eade8d288c2c50989b1fa00dc7072f4R1-R10): Created an abstract class `NmsClientboundPacketImpl` to serve as a base for client-bound packet implementations.

Configuration and version updates:

* [`.idea/vcs.xml`](diffhunk://#diff-a6dab70bd0e9ffc91d8419ad52225baff3a3e7c9d8e1724f7ed6d96b661d804aR3-R8): Added commit message inspection profiles to enforce commit message format and naming conventions.
* [`gradle.properties`](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L12-R12): Updated the project version to `1.21.4-2.13.0-SNAPSHOT`.