### PR TITLE
fix: update scoreboard library dependencies and exclude spigot-api fr…

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="CommitMessageInspectionProfile">
-    <profile version="1.0">
-      <inspection_tool class="CommitFormat" enabled="true" level="WARNING" enabled_by_default="true" />
-      <inspection_tool class="CommitNamingConvention" enabled="true" level="WARNING" enabled_by_default="true" />
-    </profile>
-  </component>
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
   </component>

--- a/surf-api-bukkit/surf-api-bukkit-api/build.gradle.kts
+++ b/surf-api-bukkit/surf-api-bukkit-api/build.gradle.kts
@@ -7,7 +7,7 @@ dependencies {
     api(project(":surf-api-core:surf-api-core-api"))
     compileOnly(libs.paper.api)
     compileOnlyApi(libs.packetevents.spigot)
-    compileOnlyApi(libs.scoreboard.library.api) { isTransitive = false }
+    api(libs.scoreboard.library.api)
     compileOnlyApi(libs.commandapi.bukkit)
     compileOnlyApi(libs.reflection.remapper)
     compileOnlyApi(libs.more.persistent.data.types)
@@ -18,3 +18,7 @@ dependencies {
 }
 
 description = "surf-api-bukkit-api"
+
+configurations.all {
+    exclude(group = "org.spigotmc", module = "spigot-api")
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
+++ b/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
@@ -28,8 +28,8 @@ dependencies {
     compileOnly(libs.placeholder.api)
 
     // -------------------- Paper Libraries -------------------- //
-    paperLibrary(libs.scoreboard.library.implementation) { isTransitive = false }
-    paperLibrary(libs.scoreboard.library.modern) { isTransitive = false }
+    runtimeOnly(libs.scoreboard.library.implementation)
+    runtimeOnly(libs.scoreboard.library.modern)
     paperLibrary(libs.scoreboard.library.api)
     api(libs.inventoryframework)
     api(libs.packetevents.spigot)
@@ -91,7 +91,7 @@ paper {
     }
 }
 
-configurations.compileClasspath {
+configurations.all {
     exclude(group = "org.spigotmc", module = "spigot-api")
 }
 


### PR DESCRIPTION
This pull request includes changes to dependency configurations and project settings, focusing on improving dependency management and cleaning up unused configurations. The most important changes involve modifying dependency scopes, excluding conflicting libraries, and removing obsolete inspection profiles.

### Dependency Management Updates:

* In `surf-api-bukkit/surf-api-bukkit-api/build.gradle.kts`, changed the `scoreboard.library.api` dependency from `compileOnlyApi` to `api` to ensure it is available to downstream consumers.
* Added a configuration-wide exclusion for the `spigot-api` library in `surf-api-bukkit/surf-api-bukkit-api/build.gradle.kts` to prevent conflicts with other dependencies.
* In `surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts`, updated `scoreboard.library.implementation` and `scoreboard.library.modern` dependencies from `paperLibrary` to `runtimeOnly` to limit their scope to runtime.
* Applied a global configuration-wide exclusion for the `spigot-api` library in `surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts` for consistency and conflict resolution.

### Project Settings Cleanup:

* Removed the `CommitMessageInspectionProfile` component from `.idea/vcs.xml`, as it is no longer needed. This simplifies the project configuration.…om compileClasspath