### PR TITLE
"CASTCRAFTER COMMUNITY SERVER" has been renamed to "CASTCRAFTER.DE" to match the new™️ logo.

### DIFF
--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/CommonComponents.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/CommonComponents.kt
@@ -69,15 +69,12 @@ object CommonComponents {
      *
      * **Output Example:**
      * ```
-     * CASTCRAFTER
-     * COMMUNITY SERVER
+     * CASTCRAFTER.DE
      * ```
      */
     @JvmField
     val DISCONNECT_HEADER = buildText0 {
-        appendText("CASTCRAFTER", PRIMARY)
-        appendNewline()
-        appendText("COMMUNITY SERVER", PRIMARY)
+        appendText("CASTCRAFTER.DE", PRIMARY)
         appendNewline(2)
     }
 
@@ -132,8 +129,7 @@ object CommonComponents {
      *
      * **Output Example:**
      * ```
-     * CASTCRAFTER
-     * COMMUNITY SERVER
+     * CASTCRAFTER.DE
      *
      * DU WURDEST VOM SERVER GEWORFEN
      * \
@@ -161,8 +157,7 @@ object CommonComponents {
      *
      * **Output Example:**
      * ```
-     * CASTCRAFTER
-     * COMMUNITY SERVER
+     * CASTCRAFTER.DE
      *
      * DU WURDEST VOM SERVER GEWORFEN
      * \
@@ -231,8 +226,7 @@ object CommonComponents {
      *
      * **Output Example:**
      * ```
-     * CASTCRAFTER
-     * COMMUNITY SERVER
+     * CASTCRAFTER.DE
      *
      * DU WURDEST VOM SERVER GEWORFEN
      * \
@@ -262,8 +256,7 @@ object CommonComponents {
      *
      * **Output Example:**
      * ```
-     * CASTCRAFTER
-     * COMMUNITY SERVER
+     * CASTCRAFTER.DE
      *
      * DU WURDEST VOM SERVER GEWORFEN
      * \


### PR DESCRIPTION
This pull request updates the `DISCONNECT_HEADER` text in the `CommonComponents` object to reflect a branding change. The text now uses "CASTCRAFTER.DE" instead of the previous "CASTCRAFTER" and "COMMUNITY SERVER" lines.

Branding update in `DISCONNECT_HEADER`:

* Updated the `DISCONNECT_HEADER` output example and implementation to replace "CASTCRAFTER" and "COMMUNITY SERVER" with "CASTCRAFTER.DE" across multiple instances. (`surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/CommonComponents.kt`) [[1]](diffhunk://#diff-326ea7b252701e45e31a8843666c027e7a78a02865366d24ff2d3f89f729716eL72-R77) [[2]](diffhunk://#diff-326ea7b252701e45e31a8843666c027e7a78a02865366d24ff2d3f89f729716eL135-R132) [[3]](diffhunk://#diff-326ea7b252701e45e31a8843666c027e7a78a02865366d24ff2d3f89f729716eL164-R160) [[4]](diffhunk://#diff-326ea7b252701e45e31a8843666c027e7a78a02865366d24ff2d3f89f729716eL234-R229) [[5]](diffhunk://#diff-326ea7b252701e45e31a8843666c027e7a78a02865366d24ff2d3f89f729716eL265-R259)