### PR TITLE
Update packetevents and packetevents-plugin versions

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=21
 mcVersion=1.21.10
 group=dev.slne.surf
-version=1.21.10-2.42.1
+version=1.21.10-2.42.2
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ kotlinxCoroutines = "1.10.2"
 kotlinx-serialization = "1.9.0"
 
 # Packet Events
-packetevents = "2.10.0-SNAPSHOT"
-packetevents-plugin = "2.10.0-SNAPSHOT"
+packetevents = "2.10.0"
+packetevents-plugin = "2.10.0"
 
 # Command API
 commandapi = "11.0.0"


### PR DESCRIPTION
Updated packetevents and packetevents-plugin versions from 2.10.0-SNAPSHOT to 2.10.0.