### PR TITLE
feat: change cloud dependency registration to use registerSoft for im…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=21
 mcVersion=1.21.10
 group=dev.slne.surf
-version=1.21.10-2.42.2
+version=1.21.10-2.42.3
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.5.3")
+    append("-1.5.4")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.surfapi.gradle.generated.Constants
 import dev.slne.surf.surfapi.gradle.generators.LibrariesLoaderGenerator.generateLibrariesLoaderTask
 import dev.slne.surf.surfapi.gradle.platform.paper.AbstractPaperSurfPlugin
 import dev.slne.surf.surfapi.gradle.util.registerRequired
+import dev.slne.surf.surfapi.gradle.util.registerSoft
 import net.minecrell.pluginyml.GeneratePluginDescription
 import net.minecrell.pluginyml.paper.PaperPluginDescription
 import org.gradle.api.Project
@@ -52,7 +53,7 @@ internal class PaperPluginSurfPlugin :
             bootstrapDependencies {
                 registerRequired("surf-bukkit-api")
                 if (extension.cloudModule.isPresent) {
-                    registerRequired("surf-cloud-bukkit")
+                    registerSoft("surf-cloud-bukkit")
                 }
 
                 extension.bootstrapDependencies.orNull?.execute(this)
@@ -61,7 +62,7 @@ internal class PaperPluginSurfPlugin :
             serverDependencies {
                 registerRequired("surf-bukkit-api")
                 if (extension.cloudModule.isPresent) {
-                    registerRequired("surf-cloud-bukkit")
+                    registerSoft("surf-cloud-bukkit")
                 }
                 extension.serverDependencies.orNull?.execute(this)
             }


### PR DESCRIPTION
This pull request updates how dependencies are registered for the Paper plugin platform in the Gradle plugin. The main change is that the `surf-cloud-bukkit` dependency is now registered as a "soft" dependency rather than a required one, depending on the presence of the cloud module. This allows for more flexibility in plugin loading and avoids hard failures if the cloud module is not present.

**Dependency registration improvements:**

* Added the `registerSoft` utility import to support soft dependency registration in `PaperPluginSurfPlugin.kt`.
* Changed the bootstrap and server dependency registration for `surf-cloud-bukkit` to use `registerSoft` instead of `registerRequired`, making it an optional dependency if the cloud module is present. [[1]](diffhunk://#diff-cd779cde6662aff055fb58d41d8f41cb0fafc06cca46490686bdb5161b28d8dfL55-R56) [[2]](diffhunk://#diff-cd779cde6662aff055fb58d41d8f41cb0fafc06cca46490686bdb5161b28d8dfL64-R65)