### PR TITLE
feat: enhance message prefixes for consistency and clarity

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=21
 mcVersion=1.21.10
 group=dev.slne.surf
-version=1.21.10-2.42.3
+version=1.21.10-2.42.4
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/Colors.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/Colors.kt
@@ -135,7 +135,7 @@ interface Colors {
         }
 
         /**
-         * The surf used across all Surf plugins, ensuring a recognizable and uniform
+         * The Surf prefix used across all Surf plugins, ensuring a recognizable and uniform
          * identifier in messages.
          */
         @JvmField

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/Colors.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/Colors.kt
@@ -1,9 +1,11 @@
 package dev.slne.surf.surfapi.core.api.messages
 
+import dev.slne.surf.surfapi.core.api.messages.adventure.buildText
 import net.kyori.adventure.text.Component
 import net.kyori.adventure.text.format.NamedTextColor
 import net.kyori.adventure.text.format.TextColor
 import net.kyori.adventure.text.format.TextColor.color
+import net.kyori.adventure.text.format.TextDecoration
 
 /**
  * A class that defines all the colors used in the Surf system, ensuring a consistent visual style
@@ -108,11 +110,36 @@ interface Colors {
         // -------------------- Default Colors -------------------- //
 
         /**
-         * The default prefix used across all Surf plugins, ensuring a recognizable and uniform
+         * The default prefix used across all Surf plugins
+         */
+        @JvmField
+        val PREFIX: Component = buildText {
+            spacer("»")
+            appendSpace()
+        }
+
+        @JvmField
+        val WARNING_PREFIX: Component = buildText {
+            spacer("[")
+            error("!", TextDecoration.BOLD)
+            spacer("]")
+            appendSpace()
+        }
+
+        @JvmField
+        val ERROR_PREFIX: Component = buildText {
+            spacer("[")
+            error("✘", TextDecoration.BOLD)
+            spacer("]")
+            appendSpace()
+        }
+
+        /**
+         * The surf used across all Surf plugins, ensuring a recognizable and uniform
          * identifier in messages.
          */
         @JvmField
-        val PREFIX: Component = Component.text(">> ", DARK_SPACER)
+        val SURF_PREFIX: Component = Component.text(">> ", DARK_SPACER)
             .append(Component.text("Surf", PREFIX_COLOR))
             .append(Component.text(" | ", DARK_SPACER))
 

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/messages/builder/SurfComponentBuilder.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.surfapi.core.api.messages.builder
 
+import dev.slne.surf.surfapi.core.api.messages.*
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.DARK_SPACER
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.ERROR
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.INFO
@@ -11,14 +12,10 @@ import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.SUCCESS
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.VARIABLE_KEY
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.VARIABLE_VALUE
 import dev.slne.surf.surfapi.core.api.messages.Colors.Companion.WARNING
-import dev.slne.surf.surfapi.core.api.messages.CommonComponents
 import dev.slne.surf.surfapi.core.api.messages.CommonComponents.DISCONNECT_HEADER
 import dev.slne.surf.surfapi.core.api.messages.CommonComponents.DISCORD_LINK
 import dev.slne.surf.surfapi.core.api.messages.CommonComponents.MAP_SEPERATOR
 import dev.slne.surf.surfapi.core.api.messages.CommonComponents.TIME_SEPARATOR
-import dev.slne.surf.surfapi.core.api.messages.NoLowercase
-import dev.slne.surf.surfapi.core.api.messages.joinToComponent
-import dev.slne.surf.surfapi.core.api.messages.joinToComponentNewLine
 import net.kyori.adventure.key.Key
 import net.kyori.adventure.text.*
 import net.kyori.adventure.text.event.ClickEvent
@@ -44,6 +41,9 @@ interface SurfComponentBuilder : TextComponent.Builder {
     }
 
     fun appendPrefix() = append(PREFIX)
+    fun appendSurfPrefix() = append(Colors.SURF_PREFIX)
+    fun appendErrorPrefix() = append(Colors.ERROR_PREFIX)
+    fun appendWarningPrefix() = append(Colors.WARNING_PREFIX)
     fun appendNewPrefixedLine() = appendNewline().appendPrefix()
 
     fun append(block: SurfComponentBuilder.() -> Unit): SurfComponentBuilder =
@@ -233,6 +233,9 @@ interface SurfComponentBuilder : TextComponent.Builder {
 
     fun darkSpacer(long: Long, vararg decoration: TextDecoration) =
         text(long, DARK_SPACER, *decoration)
+
+    fun white(any: Any, vararg decoration: TextDecoration) =
+        text(any.toString(), Colors.WHITE, *decoration)
 
     fun ellipsis(color: TextColor? = SPACER) = append(CommonComponents.ELLIPSIS.color(color))
 

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.6.1")
+    append("-1.6.2")
     if (snapshot) append("-SNAPSHOT")
 }
 


### PR DESCRIPTION
- The default prefix has been changed to remove the internal "Surf" from every public message. The prefix can still be used for internal messages.
- New prefixes have been added to the SurfComponentBuilder, for errors, warnings and the old surf prefix.
- A new color have been added to the SurfComponentBuilder, white, to display white text simple.