### PR TITLE
Fix hook metadata emission when class deps are unresolved

### DIFF
--- a/surf-api-gradle-plugin/surf-api-processor/src/main/kotlin/dev/slne/surf/surfapi/processor/hook/HookSymbolProcessor.kt
+++ b/surf-api-gradle-plugin/surf-api-processor/src/main/kotlin/dev/slne/surf/surfapi/processor/hook/HookSymbolProcessor.kt
@@ -38,6 +38,7 @@ class HookSymbolProcessor(environment: SymbolProcessorEnvironment) : SymbolProce
         val hooksMetas = resolver.getSymbolsWithAnnotation(HOOK_ANNOTATION)
             .filterIsInstance<KSClassDeclaration>()
             .mapNotNull { hookClass ->
+                var hasUnresolvedClassDependency = false
                 val hookMeta = hookClass.annotations.findAnnotation(HOOK_ANNOTATION) ?: run {
                     logger.error("@HookMeta annotation not found on element", hookClass)
                     return@mapNotNull null
@@ -54,16 +55,22 @@ class HookSymbolProcessor(environment: SymbolProcessorEnvironment) : SymbolProce
 
                         if (clazzValue.isError) {
                             deferred += hookClass
+                            hasUnresolvedClassDependency = true
                             return@mapNotNull null
                         }
 
                         val closestClass = clazzValue.declaration.closestClassDeclaration()
                         if (closestClass == null) {
                             deferred += hookClass
+                            hasUnresolvedClassDependency = true
                             return@mapNotNull null
                         }
                         closestClass.toBinaryName()
                     }
+
+                if (hasUnresolvedClassDependency) {
+                    return@mapNotNull null
+                }
 
                 val dependsOnClassName = hookClass.annotations.findAnnotations(DEPENDS_ON_CLASS_NAME_ANNOTATION)
                     .mapNotNull { annotation ->


### PR DESCRIPTION
### Motivation
- Avoid emitting incomplete or duplicate hook metadata when `@DependsOnClass` references are unresolved so generated `surf-hooks.json` does not contain entries missing class dependencies.

### Description
- In `surf-api-gradle-plugin/surf-api-processor/src/main/kotlin/.../HookSymbolProcessor.kt` track unresolved class dependencies with a `hasUnresolvedClassDependency` flag and short-circuit `mapNotNull` to `return@mapNotNull null` when any `DependsOnClass` reference is unresolved or its `closestClassDeclaration()` is missing, preventing partial `PluginHookMeta.Hook` entries.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69754470fdb08322987f62d3a8801142)