### PR TITLE
Fix/invocation handler

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.55.1
+version=1.21.11-2.55.2
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-core/surf-api-core-server/src/main/java/dev/slne/surf/surfapi/core/server/impl/reflection/SurfInvocationHandlerJava.java
+++ b/surf-api-core/surf-api-core-server/src/main/java/dev/slne/surf/surfapi/core/server/impl/reflection/SurfInvocationHandlerJava.java
@@ -6,6 +6,12 @@ import dev.slne.surf.surfapi.core.api.reflection.Static;
 import dev.slne.surf.surfapi.core.api.util.SurfUtil;
 import it.unimi.dsi.fastutil.objects.Object2ObjectMap;
 import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.apache.commons.lang3.reflect.MethodUtils;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
+
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
@@ -19,11 +25,6 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.reflect.FieldUtils;
-import org.apache.commons.lang3.reflect.MethodUtils;
-import org.jspecify.annotations.NullMarked;
-import org.jspecify.annotations.Nullable;
 
 @NullMarked
 public final class SurfInvocationHandlerJava<T> implements InvocationHandler {
@@ -176,7 +177,10 @@ public final class SurfInvocationHandlerJava<T> implements InvocationHandler {
     final Class<?>[] paramTypes = Arrays.copyOfRange(original.getParameterTypes(), paramOffset,
         original.getParameterCount());
     final String methodName = getMethodName(original, nameAnnotation, null, staticAnnotation, null);
-    final Method method = MethodUtils.getMatchingAccessibleMethod(clazz, methodName, paramTypes);
+    final Method method = MethodUtils.getMatchingMethod(clazz, methodName, paramTypes);
+    if (method != null) {
+      method.setAccessible(true);
+    }
     if (method == null) {
       throw new NoSuchMethodException(
           "Method " + methodName + " with params " + Arrays.toString(paramTypes));


### PR DESCRIPTION
This pull request includes a version bump and a minor but important fix to the reflection-based method resolution logic in `SurfInvocationHandlerJava`. The main update ensures that methods found via reflection are made accessible, which improves compatibility with Java's access control, and updates the project version.

Version update:

* Bumped the project version in `gradle.properties` from `1.21.11-2.55.1` to `1.21.11-2.55.2`.

Reflection handling improvements:

* In `SurfInvocationHandlerJava.java`, changed the reflective method lookup to use `MethodUtils.getMatchingMethod` instead of `getMatchingAccessibleMethod`, and explicitly set found methods as accessible to ensure proper invocation of non-public methods.
* Adjusted imports in `SurfInvocationHandlerJava.java` to match the new usage of reflection utilities. [[1]](diffhunk://#diff-725fb35215c32d9bff6a6cbd43b6f4938ca96f69fa68fc2d74b1ddcc8e3b6e6aR9-R14) [[2]](diffhunk://#diff-725fb35215c32d9bff6a6cbd43b6f4938ca96f69fa68fc2d74b1ddcc8e3b6e6aL22-L26)