### PR TITLE
Feat/more bridges

### DIFF
--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -2,11 +2,13 @@ import org.gradle.accessors.dm.LibrariesForLibs
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 val libs = the<LibrariesForLibs>()
+val javaVersion: String by project
 
 plugins {
     java
     `java-library`
     id("publish-convention")
+    id("java-toolchain-convention")
 
     kotlin("jvm")
     kotlin("plugin.serialization")
@@ -40,9 +42,6 @@ ksp {
 }
 
 extensions.configure<KotlinJvmProjectExtension> {
-    val javaVersion: String by project
-
-    jvmToolchain(javaVersion.toInt())
     compilerOptions {
         freeCompilerArgs = listOf("-Xjsr305=strict")
     }

--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -70,6 +70,9 @@ tasks {
     shadowJar {
         mergeServiceFiles()
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+
+        val relocationPrefix: String by project
+        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt")
     }
 
     javadoc {

--- a/buildSrc/src/main/kotlin/java-toolchain-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-convention.gradle.kts
@@ -1,0 +1,18 @@
+import gradle.kotlin.dsl.accessors._bcd9a993373509de50154c5485fe667f.java
+import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
+
+val javaVersion: String by project
+
+plugins {
+    java
+}
+
+extensions.findByType<KotlinJvmProjectExtension>()?.apply {
+    jvmToolchain(javaVersion.toInt())
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(javaVersion))
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.56.1
+version=1.21.11-2.57.0
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,6 +65,7 @@ ktor = "3.4.0"
 glm = "0.9.9.1-15"
 ksp-version = "2.3.5"
 reactor-netty = "1.3.2"
+bytebuddy = "1.18.4"
 
 # Plugin versions
 maven-repo-auth = "3.0.4"
@@ -166,6 +167,7 @@ ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negoti
 ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 reactor-netty-core = { module = "io.projectreactor.netty:reactor-netty-core", version.ref = "reactor-netty" }
 reactor-netty-http = { module = "io.projectreactor.netty:reactor-netty-http", version.ref = "reactor-netty" }
+bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
 
 # Plugin dependencies
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-9.4.0-20260128061951+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-milestone-5-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -59,6 +59,23 @@ public final class dev/slne/surf/surfapi/bukkit/api/collections/LazyIntList {
 	public final fun set (II)V
 }
 
+public final class dev/slne/surf/surfapi/bukkit/api/command/args/AdventureCompoundBinaryTagArgument : dev/jorel/commandapi/arguments/SafeOverrideableArgument {
+	public fun <init> (Ljava/lang/String;)V
+	public fun getArgumentType ()Ldev/jorel/commandapi/arguments/CommandAPIArgumentType;
+	public fun getPrimitiveType ()Ljava/lang/Class;
+	public synthetic fun parseArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Ldev/jorel/commandapi/executors/CommandArguments;)Ljava/lang/Object;
+	public fun parseArgument (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;Ldev/jorel/commandapi/executors/CommandArguments;)Lnet/kyori/adventure/nbt/CompoundBinaryTag;
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/command/args/AdventureCompoundBinaryTagArgumentKt {
+	public static final fun adventureCompoundBinaryTagArgument (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static final fun adventureCompoundBinaryTagArgument (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/CommandTree;
+	public static final fun adventureCompoundBinaryTagArgument (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;)Ldev/jorel/commandapi/arguments/Argument;
+	public static synthetic fun adventureCompoundBinaryTagArgument$default (Ldev/jorel/commandapi/CommandAPICommand;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandAPICommand;
+	public static synthetic fun adventureCompoundBinaryTagArgument$default (Ldev/jorel/commandapi/CommandTree;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/CommandTree;
+	public static synthetic fun adventureCompoundBinaryTagArgument$default (Ldev/jorel/commandapi/arguments/Argument;Ljava/lang/String;ZLkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ldev/jorel/commandapi/arguments/Argument;
+}
+
 public class dev/slne/surf/surfapi/bukkit/api/command/args/MiniMessageArgument : dev/jorel/commandapi/arguments/CustomArgument {
 	public fun <init> (Ljava/lang/String;)V
 }
@@ -770,6 +787,22 @@ public final class dev/slne/surf/surfapi/bukkit/api/nms/SurfBukkitNmsBridgeKt {
 	public static final fun getNmsBridge ()Ldev/slne/surf/surfapi/bukkit/api/nms/SurfBukkitNmsBridge;
 }
 
+public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge {
+	public static final field Companion Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge$Companion;
+	public abstract fun compoundTag ()Lcom/mojang/brigadier/arguments/ArgumentType;
+	public abstract fun getCompoundTag (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/kyori/adventure/nbt/CompoundBinaryTag;
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge$Companion : dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge {
+	public fun compoundTag ()Lcom/mojang/brigadier/arguments/ArgumentType;
+	public fun getCompoundTag (Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet/kyori/adventure/nbt/CompoundBinaryTag;
+	public final fun getInstance ()Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge;
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridgeKt {
+	public static final fun getCommandArgumentTypes ()Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge;
+}
+
 public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommonBridge {
 	public static final field Companion Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommonBridge$Companion;
 	public abstract fun addCompostable (Lorg/bukkit/Material;F)V
@@ -799,6 +832,20 @@ public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCom
 
 public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommonBridgeKt {
 	public static final fun getNmsCommonBridge ()Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommonBridge;
+}
+
+public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge {
+	public static final field Companion Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge$Companion;
+	public abstract fun createEntityByNbt (Lorg/bukkit/World;Lorg/bukkit/entity/EntityType;Lio/papermc/paper/math/FinePosition;Lnet/kyori/adventure/nbt/CompoundBinaryTag;)V
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge$Companion : dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge {
+	public fun createEntityByNbt (Lorg/bukkit/World;Lorg/bukkit/entity/EntityType;Lio/papermc/paper/math/FinePosition;Lnet/kyori/adventure/nbt/CompoundBinaryTag;)V
+	public final fun getInstance ()Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge;
+}
+
+public final class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridgeKt {
+	public static final fun getEntityBridge ()Ldev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge;
 }
 
 public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsGlowingBridge {
@@ -1490,7 +1537,9 @@ public final class dev/slne/surf/surfapi/bukkit/api/util/UtilBukkit {
 	public static final fun getCallingPlugin (I)Lorg/bukkit/plugin/java/JavaPlugin;
 	public static synthetic fun getCallingPlugin$default (IILjava/lang/Object;)Lorg/bukkit/plugin/java/JavaPlugin;
 	public static final fun getChunkKey (Lorg/bukkit/Location;)J
+	public static final fun getChunkX (Lio/papermc/paper/math/Position;)I
 	public static final fun getChunkX (Lorg/bukkit/Location;)I
+	public static final fun getChunkZ (Lio/papermc/paper/math/Position;)I
 	public static final fun getChunkZ (Lorg/bukkit/Location;)I
 	public static final fun getHighestBlockYAtBlockCoordinates (Lorg/bukkit/ChunkSnapshot;II)I
 	public static final fun getXFromChunkKey (J)I

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/command/args/AdventureCompoundBinaryTagArgument.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/command/args/AdventureCompoundBinaryTagArgument.kt
@@ -1,0 +1,54 @@
+package dev.slne.surf.surfapi.bukkit.api.command.args
+
+import com.mojang.brigadier.context.CommandContext
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.CommandTree
+import dev.jorel.commandapi.arguments.Argument
+import dev.jorel.commandapi.arguments.CommandAPIArgumentType
+import dev.jorel.commandapi.arguments.SafeOverrideableArgument
+import dev.jorel.commandapi.executors.CommandArguments
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.bukkit.api.nms.bridges.commandArgumentTypes
+import net.kyori.adventure.nbt.CompoundBinaryTag
+import net.kyori.adventure.nbt.TagStringIO
+
+@OptIn(NmsUseWithCaution::class)
+class AdventureCompoundBinaryTagArgument(nodeName: String) :
+    SafeOverrideableArgument<CompoundBinaryTag, CompoundBinaryTag>(
+        nodeName, commandArgumentTypes.compoundTag(), { TagStringIO.tagStringIO().asString(it) }
+    ) {
+    override fun getPrimitiveType(): Class<CompoundBinaryTag> {
+        return CompoundBinaryTag::class.java
+    }
+
+    override fun getArgumentType(): CommandAPIArgumentType {
+        return CommandAPIArgumentType.NBT_COMPOUND
+    }
+
+    override fun <Source> parseArgument(
+        ctx: CommandContext<Source>,
+        key: String,
+        previousArgs: CommandArguments
+    ): CompoundBinaryTag {
+        return commandArgumentTypes.getCompoundTag(ctx, key)
+    }
+}
+
+inline fun CommandTree.adventureCompoundBinaryTagArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandTree = then(AdventureCompoundBinaryTagArgument(nodeName).setOptional(optional).apply(block))
+
+inline fun Argument<*>.adventureCompoundBinaryTagArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): Argument<*> = then(AdventureCompoundBinaryTagArgument(nodeName).setOptional(optional).apply(block))
+
+
+inline fun CommandAPICommand.adventureCompoundBinaryTagArgument(
+    nodeName: String,
+    optional: Boolean = false,
+    block: Argument<*>.() -> Unit = {}
+): CommandAPICommand = withArguments(AdventureCompoundBinaryTagArgument(nodeName).setOptional(optional).apply(block))

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge.kt
@@ -2,7 +2,6 @@ package dev.slne.surf.surfapi.bukkit.api.nms.bridges
 
 import com.mojang.brigadier.arguments.ArgumentType
 import com.mojang.brigadier.context.CommandContext
-import com.mojang.brigadier.exceptions.CommandSyntaxException
 import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import net.kyori.adventure.nbt.CompoundBinaryTag
@@ -10,10 +9,8 @@ import net.kyori.adventure.nbt.CompoundBinaryTag
 @NmsUseWithCaution
 interface SurfBukkitNmsCommandArgumentTypesBridge {
 
-    fun compoundTag(): ArgumentType<CompoundBinaryTag>
-
-    @Throws(CommandSyntaxException::class)
-    fun <Source> getCompoundTag(ctx: CommandContext<Source>, key: String): CompoundBinaryTag
+    fun compoundTag(): ArgumentType<*>
+    fun getCompoundTag(ctx: CommandContext<*>, key: String): CompoundBinaryTag
 
     companion object : SurfBukkitNmsCommandArgumentTypesBridge by commandArgumentTypes {
         val instance = commandArgumentTypes

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridge.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.surfapi.bukkit.api.nms.bridges
+
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.CommandSyntaxException
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.core.api.util.requiredService
+import net.kyori.adventure.nbt.CompoundBinaryTag
+
+@NmsUseWithCaution
+interface SurfBukkitNmsCommandArgumentTypesBridge {
+
+    fun compoundTag(): ArgumentType<CompoundBinaryTag>
+
+    @Throws(CommandSyntaxException::class)
+    fun <Source> getCompoundTag(ctx: CommandContext<Source>, key: String): CompoundBinaryTag
+
+    companion object : SurfBukkitNmsCommandArgumentTypesBridge by commandArgumentTypes {
+        val instance = commandArgumentTypes
+    }
+}
+
+@NmsUseWithCaution
+val commandArgumentTypes = requiredService<SurfBukkitNmsCommandArgumentTypesBridge>()

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/nms/bridges/SurfBukkitNmsEntityBridge.kt
@@ -1,0 +1,23 @@
+package dev.slne.surf.surfapi.bukkit.api.nms.bridges
+
+import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.core.api.util.requiredService
+import io.papermc.paper.math.FinePosition
+import net.kyori.adventure.nbt.CompoundBinaryTag
+import org.bukkit.World
+import org.bukkit.entity.EntityType
+
+@NmsUseWithCaution
+interface SurfBukkitNmsEntityBridge {
+
+    @Throws(WrapperCommandSyntaxException::class)
+    fun createEntityByNbt(world: World, type: EntityType, pos: FinePosition, tag: CompoundBinaryTag)
+
+    companion object : SurfBukkitNmsEntityBridge by entityBridge {
+        val instance = entityBridge
+    }
+}
+
+@NmsUseWithCaution
+val entityBridge = requiredService<SurfBukkitNmsEntityBridge>()

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/util/bukkit-util.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/util/bukkit-util.kt
@@ -10,6 +10,7 @@ import dev.slne.surf.surfapi.core.api.util.getCallerClass
 import dev.slne.surf.surfapi.core.api.util.mutableLong2ObjectMapOf
 import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
 import io.papermc.paper.math.BlockPosition
+import io.papermc.paper.math.Position
 import it.unimi.dsi.fastutil.objects.ObjectList
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -114,6 +115,16 @@ infix fun Location.distanceSqt(other: Location): Double = distanceSquared(other)
  * Gets the chunk X coordinate of this location.
  */
 val Location.chunkX get() = blockX shr 4
+
+/**
+ * Gets the chunk X coordinate of this position.
+ */
+val Position.chunkX get() = blockX() shr 4
+
+/**
+ * Gets the chunk Z coordinate of this position.
+ */
+val Position.chunkZ get() = blockZ() shr 4
 
 /**
  * Gets the chunk Z coordinate of this location.

--- a/surf-api-bukkit/surf-api-bukkit-plugin-test/build.gradle.kts
+++ b/surf-api-bukkit/surf-api-bukkit-plugin-test/build.gradle.kts
@@ -50,7 +50,7 @@ tasks {
         minecraftVersion(findProperty("mcVersion") as String)
 
         downloadPlugins {
-//            hangar("CommandAPI", libs.versions.commandapi.get()) TODO: update to 1.21.11 when released
+            hangar("CommandAPI", libs.versions.commandapi.get())
             modrinth("packetevents", libs.versions.packetevents.plugin.get() + "+spigot")
         }
     }

--- a/surf-api-bukkit/surf-api-bukkit-plugin-test/src/main/java/dev/slne/surf/surfapi/bukkit/test/command/SurfApiTestCommand.java
+++ b/surf-api-bukkit/surf-api-bukkit-plugin-test/src/main/java/dev/slne/surf/surfapi/bukkit/test/command/SurfApiTestCommand.java
@@ -1,20 +1,7 @@
 package dev.slne.surf.surfapi.bukkit.test.command;
 
 import dev.jorel.commandapi.CommandAPICommand;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.CommandExceptionTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.GlowingTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.InventoryTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.MaxStacksizeTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.PacketEntityTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.PacketLoreTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.PaginationTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.PrefixConfigTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.ReflectionTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.ScoreboardTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.SmoothTimeSkip;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.SuspendCommandExecutionTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.ToastTest;
-import dev.slne.surf.surfapi.bukkit.test.command.subcommands.VisualizerTest;
+import dev.slne.surf.surfapi.bukkit.test.command.subcommands.*;
 import dev.slne.surf.surfapi.bukkit.test.command.subcommands.gui.InventoryFrameworkTest;
 
 public class SurfApiTestCommand extends CommandAPICommand {
@@ -38,8 +25,9 @@ public class SurfApiTestCommand extends CommandAPICommand {
         new GlowingTest("glowing"),
         new PaginationTest("pagination"),
         new InventoryTest("inventory"),
-        new ToastTest(("toast")),
-        new SuspendCommandExecutionTest("suspendCommandExecution")
+        new ToastTest("toast"),
+        new SuspendCommandExecutionTest("suspendCommandExecution"),
+        new SummonCommandTest("summoncommand")
     );
   }
 }

--- a/surf-api-bukkit/surf-api-bukkit-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SummonCommandTest.kt
+++ b/surf-api-bukkit/surf-api-bukkit-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SummonCommandTest.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.surfapi.bukkit.test.command.subcommands
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.entityTypeArgument
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.surfapi.bukkit.api.command.args.adventureCompoundBinaryTagArgument
+import dev.slne.surf.surfapi.bukkit.api.nms.bridges.entityBridge
+import net.kyori.adventure.nbt.CompoundBinaryTag
+import org.bukkit.entity.EntityType
+
+class SummonCommandTest(name: String) : CommandAPICommand(name) {
+    init {
+        entityTypeArgument("type")
+        adventureCompoundBinaryTagArgument("nbt")
+
+        playerExecutor { sender, args ->
+            val type: EntityType by args
+            val nbt: CompoundBinaryTag by args
+
+            entityBridge.createEntityByNbt(sender.world, type, sender.location, nbt)
+        }
+    }
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
+++ b/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
@@ -100,7 +100,6 @@ tasks {
     shadowJar {
         val relocationPrefix: String by project
         relocate("me.devnatan.inventoryframework", "$relocationPrefix.devnatan.inventoryframework")
-        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt")
     }
 }
 

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridgeImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridgeImpl.kt
@@ -1,0 +1,113 @@
+package dev.slne.surf.surfapi.bukkit.server.impl.nms.bridges
+
+import com.google.auto.service.AutoService
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.context.CommandContext
+import com.mojang.brigadier.exceptions.CommandSyntaxException
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.bukkit.api.nms.bridges.SurfBukkitNmsCommandArgumentTypesBridge
+import dev.slne.surf.surfapi.bukkit.server.nms.AdventureNBT
+import dev.slne.surf.surfapi.bukkit.server.reflection.Reflection
+import dev.slne.surf.surfapi.core.api.util.checkInstantiationByServiceLoader
+import net.bytebuddy.ByteBuddy
+import net.bytebuddy.dynamic.loading.ClassLoadingStrategy
+import net.bytebuddy.dynamic.scaffold.TypeValidation
+import net.bytebuddy.implementation.InvocationHandlerAdapter
+import net.bytebuddy.implementation.bind.annotation.RuntimeType
+import net.bytebuddy.matcher.ElementMatchers
+import net.kyori.adventure.nbt.CompoundBinaryTag
+import net.minecraft.commands.arguments.CompoundTagArgument
+import java.lang.reflect.InvocationHandler
+import java.util.concurrent.ConcurrentHashMap
+
+@NmsUseWithCaution
+@AutoService(SurfBukkitNmsCommandArgumentTypesBridge::class)
+class SurfBukkitNmsCommandArgumentTypesBridgeImpl : SurfBukkitNmsCommandArgumentTypesBridge {
+    init {
+        checkInstantiationByServiceLoader()
+    }
+
+    override fun compoundTag(): ArgumentType<CompoundBinaryTag> {
+        return wrap(CompoundTagArgument.compoundTag()) {
+            AdventureNBT.fromNms(it)
+        }
+    }
+
+    override fun <Source> getCompoundTag(ctx: CommandContext<Source>, key: String): CompoundBinaryTag {
+        val nms = ctx.getArgument(key, CompoundBinaryTag::class.java)
+        return nms
+    }
+
+    private fun <B : Any, C : Any> wrap(
+        base: ArgumentType<B>,
+        converter: OpenedResultConverter<B, C>
+    ): ArgumentType<C> {
+        val wrappedConverter = OpenedResultConverterImpl.of(converter)
+        val wrapped = Reflection.VANILLA_ARGUMENT_PROVIDER_IMPL_PROXY.wrap(
+            Reflection.VANILLA_ARGUMENT_PROVIDER_PROXY.provider(),
+            base,
+            wrappedConverter
+        ) as ArgumentType<C>
+
+        return wrapped
+    }
+
+
+    fun interface OpenedResultConverter<T, R> {
+        @Throws(CommandSyntaxException::class)
+        fun convert(type: T): R
+    }
+
+    object OpenedResultConverterImpl {
+        private val converterCache = ConcurrentHashMap<String, Any>()
+
+        @Suppress("UNCHECKED_CAST")
+        fun <B : Any, C : Any> of(converter: OpenedResultConverter<B, C>): Any {
+            val cacheKey = "${converter.javaClass.name}_${System.identityHashCode(converter)}"
+
+            return converterCache.computeIfAbsent(cacheKey) {
+                createConverter(converter)
+            }
+        }
+
+        private fun <B : Any, C : Any> createConverter(converter: OpenedResultConverter<B, C>): Any {
+            val resultConverterInterface = Class.forName(
+                "io.papermc.paper.command.brigadier.argument.VanillaArgumentProviderImpl\$ResultConverter"
+            )
+
+            val handler = InvocationHandler { _, method, args ->
+                when (method.name) {
+                    "convert" -> converter.convert(args[0] as B)
+                    else -> throw UnsupportedOperationException("Unknown method: ${method.name}")
+                }
+            }
+
+            val dynamicType = ByteBuddy()
+                .with(TypeValidation.DISABLED)
+                .subclass(Any::class.java)
+                .implement(resultConverterInterface)
+                .name("io.papermc.paper.command.brigadier.argument.GeneratedResultConverter\$${System.nanoTime()}")
+                .method(ElementMatchers.any())
+                .intercept(InvocationHandlerAdapter.of(handler))
+                .make()
+
+            val loadedClass = dynamicType.load(
+                resultConverterInterface.classLoader,
+                ClassLoadingStrategy.Default.INJECTION
+            ).loaded
+
+            return loadedClass.getDeclaredConstructor().newInstance()
+        }
+
+
+        class InterceptorHolder<B : Any, C : Any>(
+            private val converter: OpenedResultConverter<B, C>
+        ) {
+            @RuntimeType
+            @Throws(Exception::class)
+            fun convert(@RuntimeType input: B): C {
+                return converter.convert(input)
+            }
+        }
+    }
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridgeImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsCommandArgumentTypesBridgeImpl.kt
@@ -27,15 +27,13 @@ class SurfBukkitNmsCommandArgumentTypesBridgeImpl : SurfBukkitNmsCommandArgument
         checkInstantiationByServiceLoader()
     }
 
-    override fun compoundTag(): ArgumentType<CompoundBinaryTag> {
-        return wrap(CompoundTagArgument.compoundTag()) {
-            AdventureNBT.fromNms(it)
-        }
+    override fun compoundTag(): ArgumentType<*> {
+        return CompoundTagArgument.compoundTag()
     }
 
-    override fun <Source> getCompoundTag(ctx: CommandContext<Source>, key: String): CompoundBinaryTag {
-        val nms = ctx.getArgument(key, CompoundBinaryTag::class.java)
-        return nms
+    override fun getCompoundTag(ctx: CommandContext<*>, key: String): CompoundBinaryTag {
+        val nms = CompoundTagArgument.getCompoundTag(ctx, key)
+        return AdventureNBT.fromNms(nms)
     }
 
     private fun <B : Any, C : Any> wrap(

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsEntityBridgeImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/nms/bridges/SurfBukkitNmsEntityBridgeImpl.kt
@@ -1,0 +1,47 @@
+package dev.slne.surf.surfapi.bukkit.server.impl.nms.bridges
+
+import ca.spottedleaf.moonrise.common.util.TickThread
+import com.google.auto.service.AutoService
+import com.mojang.brigadier.exceptions.CommandSyntaxException
+import dev.jorel.commandapi.exceptions.WrapperCommandSyntaxException
+import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
+import dev.slne.surf.surfapi.bukkit.api.nms.bridges.SurfBukkitNmsEntityBridge
+import dev.slne.surf.surfapi.bukkit.api.util.chunkX
+import dev.slne.surf.surfapi.bukkit.api.util.chunkZ
+import dev.slne.surf.surfapi.bukkit.server.nms.AdventureNBT
+import dev.slne.surf.surfapi.bukkit.server.nms.toNms
+import dev.slne.surf.surfapi.bukkit.server.nms.toNmsHolder
+import dev.slne.surf.surfapi.core.api.util.checkInstantiationByServiceLoader
+import io.papermc.paper.math.FinePosition
+import net.kyori.adventure.nbt.CompoundBinaryTag
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.commands.SummonCommand
+import org.bukkit.World
+import org.bukkit.entity.EntityType
+
+@NmsUseWithCaution
+@AutoService(SurfBukkitNmsEntityBridge::class)
+class SurfBukkitNmsEntityBridgeImpl : SurfBukkitNmsEntityBridge {
+    init {
+        checkInstantiationByServiceLoader()
+    }
+
+    override fun createEntityByNbt(
+        world: World,
+        type: EntityType,
+        pos: FinePosition,
+        tag: CompoundBinaryTag
+    ) {
+        val worldNMS = world.toNms()
+        TickThread.ensureTickThread(worldNMS, pos.chunkX, pos.chunkZ, "Cannot create entity asynchronously")
+
+        val source = MinecraftServer.getServer().createCommandSourceStack()
+            .withLevel(worldNMS)
+
+        try {
+            SummonCommand.createEntity(source, type.toNmsHolder(), pos.toNms(), AdventureNBT.toNms(tag), false)
+        } catch (e: CommandSyntaxException) {
+            throw WrapperCommandSyntaxException(e)
+        }
+    }
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/AdventureNBT.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/AdventureNBT.kt
@@ -60,4 +60,37 @@ object AdventureNBT {
 
         return nmsTag
     }
+
+    fun fromNms(nms: CompoundTag): CompoundBinaryTag = CompoundBinaryTag.builder().also { builder ->
+        nms.forEach { key, tag -> builder.put(key, fromNms(tag)) }
+    }.build()
+
+    fun fromNms(nms: Tag): BinaryTag = when (nms) {
+        is IntTag -> IntBinaryTag.intBinaryTag(nms.intValue())
+        is ByteTag -> ByteBinaryTag.byteBinaryTag(nms.byteValue())
+        is FloatTag -> FloatBinaryTag.floatBinaryTag(nms.floatValue())
+        is LongTag -> LongBinaryTag.longBinaryTag(nms.longValue())
+        is DoubleTag -> DoubleBinaryTag.doubleBinaryTag(nms.doubleValue())
+        is ShortTag -> ShortBinaryTag.shortBinaryTag(nms.shortValue())
+        is StringTag -> StringBinaryTag.stringBinaryTag(nms.value())
+        is ByteArrayTag -> ByteArrayBinaryTag.byteArrayBinaryTag(*nms.asByteArray)
+        is IntArrayTag -> IntArrayBinaryTag.intArrayBinaryTag(*nms.asIntArray)
+        is LongArrayTag -> LongArrayBinaryTag.longArrayBinaryTag(*nms.asLongArray)
+        is EndTag -> EndBinaryTag.endBinaryTag()
+        is ListTag -> {
+            val tag = ListBinaryTag.heterogeneousListBinaryTag()
+            for (t in nms) {
+                tag.add(fromNms(t))
+            }
+            tag.build()
+        }
+
+        is CompoundTag -> {
+            val adventure = CompoundBinaryTag.builder()
+            nms.forEach { key, tag ->
+                adventure.put(key, fromNms(tag))
+            }
+            adventure.build()
+        }
+    }
 }

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/AdventureNBT.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/AdventureNBT.kt
@@ -1,0 +1,63 @@
+package dev.slne.surf.surfapi.bukkit.server.nms
+
+import net.kyori.adventure.nbt.*
+import net.minecraft.nbt.*
+
+object AdventureNBT {
+    fun toNms(
+        adventure: CompoundBinaryTag,
+        accounter: NbtAccounter = NbtAccounter.unlimitedHeap()
+    ): CompoundTag {
+        return CompoundTag().also { tag ->
+            for ((key, value) in adventure) {
+                tag.put(key, toNms(value, accounter))
+            }
+        }
+    }
+
+    fun toNms(
+        adventure: BinaryTag,
+        accounter: NbtAccounter = NbtAccounter.unlimitedHeap()
+    ): Tag {
+        accounter.pushDepth()
+
+        val nmsTag = when (adventure) {
+            is IntBinaryTag -> IntTag.valueOf(adventure.value())
+            is ByteBinaryTag -> ByteTag.valueOf(adventure.value())
+            is FloatBinaryTag -> FloatTag.valueOf(adventure.value())
+            is LongBinaryTag -> LongTag.valueOf(adventure.value())
+            is DoubleBinaryTag -> DoubleTag.valueOf(adventure.value())
+            is ShortBinaryTag -> ShortTag.valueOf(adventure.value())
+            is StringBinaryTag -> StringTag.valueOf(adventure.value())
+            is ByteArrayBinaryTag -> ByteArrayTag(adventure.value())
+            is IntArrayBinaryTag -> IntArrayTag(adventure.value())
+            is LongArrayBinaryTag -> LongArrayTag(adventure.value())
+            is EndBinaryTag -> EndTag.INSTANCE
+            is ListBinaryTag -> if (adventure.isEmpty) {
+                ListTag()
+            } else {
+                val list = ListTag()
+                for (entry in adventure) {
+                    val nms = toNms(entry)
+                    list.add(nms)
+                }
+                list
+            }
+
+            is CompoundBinaryTag -> {
+                val tag = CompoundTag()
+                for ((key, entry) in adventure) {
+                    val nms = toNms(entry)
+                    tag.put(key, nms)
+                }
+                tag
+            }
+
+            else -> throw IllegalArgumentException("Unsupported tag type: ${adventure::class}")
+        }
+
+        accounter.popDepth()
+
+        return nmsTag
+    }
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/nms-extensions.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/nms/nms-extensions.kt
@@ -12,6 +12,7 @@ import io.papermc.paper.math.FinePosition
 import io.papermc.paper.math.Position
 import net.minecraft.advancements.AdvancementType
 import net.minecraft.core.BlockPos
+import net.minecraft.core.Holder
 import net.minecraft.network.chat.Component
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
@@ -128,6 +129,9 @@ val craftServer: CraftServer get() = server.toCraft()
 val commodore: Commodore get() = CraftMagicNumbers.INSTANCE.commodore
 
 fun EntityType.toNms(): net.minecraft.world.entity.EntityType<*> = CraftEntityType.bukkitToMinecraft(this)
+fun EntityType.toNmsHolder() =
+    CraftEntityType.bukkitToMinecraftHolder(this) as Holder.Reference<net.minecraft.world.entity.EntityType<*>>
+
 fun World.toNms(): ServerLevel = (this as CraftWorld).handle
 fun Entity.toNms(): net.minecraft.world.entity.Entity = (this as CraftEntity).handle
 fun LivingEntity.toNms(): net.minecraft.world.entity.LivingEntity = (this as CraftLivingEntity).handle

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/Reflection.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/Reflection.kt
@@ -12,6 +12,8 @@ object Reflection {
     val ENTITY_PROXY: EntityProxy
     val SERVER_CONNECTION_LISTENER_PROXY: ServerConnectionListenerProxy
     val JAVA_PLUGIN_PROXY: JavaPluginProxy
+    val VANILLA_ARGUMENT_PROVIDER_IMPL_PROXY: VanillaArgumentProviderImplProxy
+    val VANILLA_ARGUMENT_PROVIDER_PROXY: VanillaArgumentProviderProxy
 
     init {
         val remapper = ReflectionRemapper.forReobfMappingsInPaperJar()
@@ -23,6 +25,8 @@ object Reflection {
         ENTITY_PROXY = proxyFactory.reflectionProxy<EntityProxy>()
         SERVER_CONNECTION_LISTENER_PROXY = proxyFactory.reflectionProxy<ServerConnectionListenerProxy>()
         JAVA_PLUGIN_PROXY = surfReflection.createProxy<JavaPluginProxy>()
+        VANILLA_ARGUMENT_PROVIDER_IMPL_PROXY = surfReflection.createProxy<VanillaArgumentProviderImplProxy>()
+        VANILLA_ARGUMENT_PROVIDER_PROXY = surfReflection.createProxy<VanillaArgumentProviderProxy>()
 
         // gc the remapper
         System.gc()

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/VanillaArgumentProviderImplProxy.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/VanillaArgumentProviderImplProxy.kt
@@ -1,0 +1,15 @@
+package dev.slne.surf.surfapi.bukkit.server.reflection
+
+import com.mojang.brigadier.arguments.ArgumentType
+import com.mojang.brigadier.exceptions.CommandSyntaxException
+import dev.slne.surf.surfapi.core.api.reflection.Name
+import dev.slne.surf.surfapi.core.api.reflection.SurfProxy
+import io.papermc.paper.command.brigadier.argument.VanillaArgumentProviderImpl
+
+@SurfProxy(VanillaArgumentProviderImpl::class)
+interface VanillaArgumentProviderImplProxy {
+
+    @Name("wrap")
+    @Throws(CommandSyntaxException::class)
+    fun wrap(instance: Any, base: Any, converter: Any): ArgumentType<*>
+}

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/VanillaArgumentProviderProxy.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/reflection/VanillaArgumentProviderProxy.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.surfapi.bukkit.server.reflection
+
+import dev.slne.surf.surfapi.core.api.reflection.Name
+import dev.slne.surf.surfapi.core.api.reflection.Static
+import dev.slne.surf.surfapi.core.api.reflection.SurfProxy
+
+@SurfProxy(qualifiedName = "io.papermc.paper.command.brigadier.argument.VanillaArgumentProvider")
+interface VanillaArgumentProviderProxy {
+
+    @Static
+    @Name("provider")
+    fun provider(): Any
+}

--- a/surf-api-core/surf-api-core-server/build.gradle.kts
+++ b/surf-api-core/surf-api-core-server/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     api(project(":surf-api-core:surf-api-core-api"))
     api(project(":surf-api-shared:surf-api-shared-internal"))
     compileOnly(libs.packetevents.netty.common)
+    api(libs.bytebuddy)
 }
 
 description = "surf-api-core-server"

--- a/surf-api-core/surf-api-core-server/src/main/java/dev/slne/surf/surfapi/core/server/impl/reflection/SurfInvocationHandlerJava.java
+++ b/surf-api-core/surf-api-core-server/src/main/java/dev/slne/surf/surfapi/core/server/impl/reflection/SurfInvocationHandlerJava.java
@@ -29,252 +29,287 @@ import java.util.stream.Collectors;
 @NullMarked
 public final class SurfInvocationHandlerJava<T> implements InvocationHandler {
 
-  private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
-  private static final Object[] EMPTY_ARGS = new Object[0];
+    private static final MethodHandles.Lookup LOOKUP = MethodHandles.lookup();
+    private static final Object[] EMPTY_ARGS = new Object[0];
 
-  private final Class<T> proxyClass;
-  private final Class<?> proxiedClass;
-  private final Object2ObjectMap<Method, Invokable> cache;
-  private final Map<Method, MethodHandle> defaultCache = new ConcurrentHashMap<>();
+    private final Class<T> proxyClass;
+    private final Class<?> proxiedClass;
+    private final Object2ObjectMap<Method, Invokable> cache;
+    private final Map<Method, MethodHandle> defaultCache = new ConcurrentHashMap<>();
 
-  public SurfInvocationHandlerJava(Class<T> proxyClass, Class<?> proxiedClass) {
-    this.proxyClass = proxyClass;
-    this.proxiedClass = proxiedClass;
-    this.cache = buildCache();
-  }
-
-  @Override
-  public @Nullable Object invoke(final Object proxy, final Method method,
-      final Object @Nullable [] args)
-      throws Throwable {
-    if (isEqualsMethod(method)) {
-      return Objects.equals(proxy, Objects.requireNonNull(args)[0]);
-    } else if (isHashCodeMethod(method)) {
-      return System.identityHashCode(proxy);
-    } else if (isToStringMethod(method)) {
-      return ToStringBuilder.reflectionToString(proxy);
-    } else if (method.isDefault()) {
-      return invokeDefault(proxy, method, args);
-    } else {
-      final Invokable invokable = cache.get(method);
-      if (invokable == null) {
-        throw new IllegalStateException("No handler cached for " + method.getName());
-      } else {
-        return invokable.invoke(args != null ? args : EMPTY_ARGS);
-      }
+    public SurfInvocationHandlerJava(Class<T> proxyClass, Class<?> proxiedClass) {
+        this.proxyClass = proxyClass;
+        this.proxiedClass = proxiedClass;
+        this.cache = buildCache();
     }
-  }
 
-  private @Nullable Object invokeDefault(final Object proxy, final Method method,
-      final Object @Nullable [] args)
-      throws Throwable {
-    final MethodHandle handle = defaultCache.computeIfAbsent(method,
-        m -> sneaky(() -> normalizeMethodHandleType(
-            MethodHandles.privateLookupIn(proxyClass, LOOKUP)
-                .findSpecial(
-                    proxyClass,
-                    m.getName(),
-                    MethodType.methodType(method.getReturnType(), method.getParameterTypes()),
-                    proxyClass
-                )
-                .bindTo(proxy)
-        )));
+    @Override
+    public @Nullable Object invoke(final Object proxy, final Method method,
+                                   final Object @Nullable [] args)
+            throws Throwable {
+        if (isEqualsMethod(method)) {
+            return Objects.equals(proxy, Objects.requireNonNull(args)[0]);
+        } else if (isHashCodeMethod(method)) {
+            return System.identityHashCode(proxy);
+        } else if (isToStringMethod(method)) {
+            return ToStringBuilder.reflectionToString(proxy);
+        } else if (method.isDefault()) {
+            return invokeDefault(proxy, method, args);
+        } else {
+            final Invokable invokable = cache.get(method);
+            if (invokable == null) {
+                throw new IllegalStateException("No handler cached for " + method.getName());
+            } else {
+                return invokable.invoke(args != null ? args : EMPTY_ARGS);
+            }
+        }
+    }
 
-    return args == null ? handle.invokeExact() : handle.invokeExact(args);
-  }
+    private @Nullable Object invokeDefault(final Object proxy, final Method method,
+                                           final Object @Nullable [] args)
+            throws Throwable {
+        final MethodHandle handle = defaultCache.computeIfAbsent(method,
+                m -> sneaky(() -> normalizeMethodHandleType(
+                        MethodHandles.privateLookupIn(proxyClass, LOOKUP)
+                                .findSpecial(
+                                        proxyClass,
+                                        m.getName(),
+                                        MethodType.methodType(method.getReturnType(), method.getParameterTypes()),
+                                        proxyClass
+                                )
+                                .bindTo(proxy)
+                )));
 
-  private Object2ObjectMap<Method, Invokable> buildCache() {
-    return Arrays.stream(proxyClass.getDeclaredMethods())
-        .filter(m -> !m.isSynthetic())
-        .filter(m -> !m.isDefault())
-        .filter(m -> !isEqualsHashOrToStringMethod(m))
-        .collect(Collectors.toMap(Function.identity(), this::createInvokable, (e1, e2) -> e1,
-            Object2ObjectOpenHashMap::new));
-  }
+        return args == null ? handle.invokeExact() : handle.invokeExact(args);
+    }
 
-  private Invokable createInvokable(final Method method) {
-    final var fieldAnnotation = method.getDeclaredAnnotation(
-        dev.slne.surf.surfapi.core.api.reflection.Field.class);
-    final var staticAnnotation = method.getDeclaredAnnotation(Static.class);
-    final var constructorAnnotation = method.getDeclaredAnnotation(
-        dev.slne.surf.surfapi.core.api.reflection.Constructor.class);
-    final var nameAnnotation = method.getDeclaredAnnotation(Name.class);
-    final var privateLookup = sneaky(() -> MethodHandles.privateLookupIn(proxiedClass, LOOKUP));
+    private Object2ObjectMap<Method, Invokable> buildCache() {
+        return Arrays.stream(proxyClass.getDeclaredMethods())
+                .filter(m -> !m.isSynthetic())
+                .filter(m -> !m.isDefault())
+                .filter(m -> !isEqualsHashOrToStringMethod(m))
+                .collect(Collectors.toMap(Function.identity(), this::createInvokable, (e1, e2) -> e1,
+                        Object2ObjectOpenHashMap::new));
+    }
 
-    if (fieldAnnotation != null) {
-      final String fieldName = getMethodName(method, nameAnnotation, fieldAnnotation,
-          staticAnnotation, constructorAnnotation);
-      final Field field = sneaky(() -> findField(proxiedClass, fieldName));
-      final boolean isGetter = fieldAnnotation.type() == Type.GETTER;
-      final MethodHandle handleGetter =
-          isGetter ? sneaky(() -> privateLookup.unreflectGetter(field)) : null;
-      final MethodHandle handleSetter = !isGetter && !fieldAnnotation.overrideFinal()
-          ? sneaky(() -> privateLookup.unreflectSetter(field)) : null;
+    private Invokable createInvokable(final Method method) {
+        final var fieldAnnotation = method.getDeclaredAnnotation(
+                dev.slne.surf.surfapi.core.api.reflection.Field.class);
+        final var staticAnnotation = method.getDeclaredAnnotation(Static.class);
+        final var constructorAnnotation = method.getDeclaredAnnotation(
+                dev.slne.surf.surfapi.core.api.reflection.Constructor.class);
+        final var nameAnnotation = method.getDeclaredAnnotation(Name.class);
+        final var privateLookup = sneaky(() -> MethodHandles.privateLookupIn(proxiedClass, LOOKUP));
 
-      if (isGetter) {
-        checkParamCount(method, staticAnnotation != null ? 0 : 1);
-        return new HandleInvokable(normalizeMethodHandleType(handleGetter));
-      } else {
-        if (fieldAnnotation.overrideFinal()) {
-          checkParamCount(method, staticAnnotation != null ? 1 : 2);
-          return new ReflectionSetterInvokable(field, staticAnnotation != null);
+        if (fieldAnnotation != null) {
+            final String fieldName = getMethodName(method, nameAnnotation, fieldAnnotation,
+                    staticAnnotation, constructorAnnotation);
+            final Field field = sneaky(() -> findField(proxiedClass, fieldName));
+            final boolean isGetter = fieldAnnotation.type() == Type.GETTER;
+            final MethodHandle handleGetter =
+                    isGetter ? sneaky(() -> privateLookup.unreflectGetter(field)) : null;
+            final MethodHandle handleSetter = !isGetter && !fieldAnnotation.overrideFinal()
+                    ? sneaky(() -> privateLookup.unreflectSetter(field)) : null;
+
+            if (isGetter) {
+                checkParamCount(method, staticAnnotation != null ? 0 : 1);
+                final boolean hasParams = staticAnnotation == null; // instance parameter
+                return new HandleInvokable(normalizeMethodHandleType(handleGetter), hasParams);
+            } else {
+                if (fieldAnnotation.overrideFinal()) {
+                    checkParamCount(method, staticAnnotation != null ? 1 : 2);
+                    return new ReflectionSetterInvokable(field, staticAnnotation != null);
+                }
+
+                checkParamCount(method, staticAnnotation != null ? 1 : 2);
+                final boolean hasParams = true; // setter always has params
+                return new HandleInvokable(normalizeMethodHandleType(handleSetter), hasParams);
+            }
         }
 
-        checkParamCount(method, staticAnnotation != null ? 1 : 2);
-        return new HandleInvokable(normalizeMethodHandleType(handleSetter));
-      }
+        if (constructorAnnotation != null) {
+            final var handle = sneaky(
+                    () -> privateLookup.unreflectConstructor(findConstructor(proxiedClass, method)));
+            final boolean hasParams = handle.type().parameterCount() > 0;
+            return new HandleInvokable(normalizeMethodHandleType(handle), hasParams);
+        }
+
+        if (staticAnnotation == null && method.getParameterCount() == 0) {
+            throw new IllegalStateException(
+                    "Instance method '" + method.getName() + "' must have a receiver parameter");
+        }
+
+        final Method target = sneaky(
+                () -> findMethod(proxiedClass, method, nameAnnotation, staticAnnotation));
+        final MethodHandle handle = sneaky(() -> privateLookup.unreflect(target));
+        final boolean hasParams = handle.type().parameterCount() > 0;
+        return new HandleInvokable(normalizeMethodHandleType(handle), hasParams);
     }
 
-    if (constructorAnnotation != null) {
-      final var handle = sneaky(
-          () -> privateLookup.unreflectConstructor(findConstructor(proxiedClass, method)));
-      return new HandleInvokable(normalizeMethodHandleType(handle));
+    private static MethodHandle normalizeMethodHandleType(final MethodHandle handle) {
+        if (handle.type().parameterCount() == 0) {
+            return handle.asType(MethodType.methodType(Object.class));
+        } else {
+            return handle.asSpreader(Object[].class, handle.type().parameterCount())
+                    .asType(MethodType.methodType(Object.class, Object[].class));
+        }
     }
 
-    if (staticAnnotation == null && method.getParameterCount() == 0) {
-      throw new IllegalStateException(
-          "Instance method '" + method.getName() + "' must have a receiver parameter");
+    private static Field findField(final Class<?> clazz, final String name)
+            throws NoSuchFieldException {
+        final Field field = FieldUtils.getField(clazz, name, true);
+        if (field == null) {
+            throw new NoSuchFieldException(name);
+        }
+        return field;
     }
 
-    final Method target = sneaky(
-        () -> findMethod(proxiedClass, method, nameAnnotation, staticAnnotation));
-    final MethodHandle handle = sneaky(() -> privateLookup.unreflect(target));
-    return new HandleInvokable(normalizeMethodHandleType(handle));
-  }
-
-  private static MethodHandle normalizeMethodHandleType(final MethodHandle handle) {
-    if (handle.type().parameterCount() == 0) {
-      return handle.asType(MethodType.methodType(Object.class));
-    } else {
-      return handle.asSpreader(Object[].class, handle.type().parameterCount())
-          .asType(MethodType.methodType(Object.class, Object[].class));
+    private static Constructor<?> findConstructor(final Class<?> clazz, final Method method)
+            throws NoSuchMethodException {
+        final Constructor<?> constructor = clazz.getDeclaredConstructor(method.getParameterTypes());
+        constructor.setAccessible(true);
+        return constructor;
     }
-  }
 
-  private static Field findField(final Class<?> clazz, final String name)
-      throws NoSuchFieldException {
-    final Field field = FieldUtils.getField(clazz, name, true);
-    if (field == null) {
-      throw new NoSuchFieldException(name);
+    private static Method findMethod(
+            final Class<?> clazz,
+            final Method original,
+            final Name nameAnnotation,
+            final @Nullable Static staticAnnotation
+    ) throws NoSuchMethodException {
+        final int paramOffset = staticAnnotation == null ? 1 : 0;  // instance param first if not static
+        final Class<?>[] paramTypes = Arrays.copyOfRange(original.getParameterTypes(), paramOffset,
+                original.getParameterCount());
+        final String methodName = getMethodName(original, nameAnnotation, null, staticAnnotation, null);
+        Method method = MethodUtils.getMatchingMethod(clazz, methodName, paramTypes);
+
+        if (method == null && isAllObjectParams(paramTypes)) {
+            method = findMethodByNameAndParamCount(clazz, methodName, paramTypes.length);
+        }
+
+        if (method != null) {
+            method.setAccessible(true);
+        }
+
+        if (method == null) {
+            throw new NoSuchMethodException(
+                    "Method '" + methodName + "' with params " + Arrays.toString(paramTypes));
+        }
+
+        return method;
     }
-    return field;
-  }
 
-  private static Constructor<?> findConstructor(final Class<?> clazz, final Method method)
-      throws NoSuchMethodException {
-    final Constructor<?> constructor = clazz.getDeclaredConstructor(method.getParameterTypes());
-    constructor.setAccessible(true);
-    return constructor;
-  }
-
-
-  private static Method findMethod(
-      final Class<?> clazz,
-      final Method original,
-      final Name nameAnnotation,
-      final @Nullable Static staticAnnotation
-  ) throws NoSuchMethodException {
-    final int paramOffset = staticAnnotation == null ? 1 : 0;  // instance param first if not static
-    final Class<?>[] paramTypes = Arrays.copyOfRange(original.getParameterTypes(), paramOffset,
-        original.getParameterCount());
-    final String methodName = getMethodName(original, nameAnnotation, null, staticAnnotation, null);
-    final Method method = MethodUtils.getMatchingMethod(clazz, methodName, paramTypes);
-    if (method != null) {
-      method.setAccessible(true);
+    private static @Nullable Method findMethodByNameAndParamCount(
+            final Class<?> clazz,
+            final String methodName,
+            final int paramCount
+    ) {
+        for (Method method : clazz.getDeclaredMethods()) {
+            if (method.getName().equals(methodName) && method.getParameterCount() == paramCount) {
+                return method;
+            }
+        }
+        return null;
     }
-    if (method == null) {
-      throw new NoSuchMethodException(
-          "Method " + methodName + " with params " + Arrays.toString(paramTypes));
+
+    private static boolean isAllObjectParams(final Class<?>[] paramTypes) {
+        for (Class<?> type : paramTypes) {
+            if (type != Object.class) {
+                return false;
+            }
+        }
+        return true;
     }
-    return method;
-  }
 
-
-  private static String getMethodName(
-      final Method method,
-      final @Nullable Name nameAnnotation,
-      final dev.slne.surf.surfapi.core.api.reflection.@Nullable Field fieldAnnotation,
-      final @Nullable Static staticAnnotation,
-      final dev.slne.surf.surfapi.core.api.reflection.@Nullable Constructor constructorAnnotation
-  ) {
-    // when block converted to if-else structure
-    if (nameAnnotation != null && !nameAnnotation.value().isBlank()) {
-      return nameAnnotation.value();
-    } else if (fieldAnnotation != null && !fieldAnnotation.name().isBlank()) {
-      return fieldAnnotation.name();
-    } else if (staticAnnotation != null && !staticAnnotation.name().isBlank()) {
-      return staticAnnotation.name();
-    } else if (constructorAnnotation != null) {
-      return method.getReturnType().getSimpleName();
-    } else {
-      return method.getName();
+    private static String getMethodName(
+            final Method method,
+            final @Nullable Name nameAnnotation,
+            final dev.slne.surf.surfapi.core.api.reflection.@Nullable Field fieldAnnotation,
+            final @Nullable Static staticAnnotation,
+            final dev.slne.surf.surfapi.core.api.reflection.@Nullable Constructor constructorAnnotation
+    ) {
+        // when block converted to if-else structure
+        if (nameAnnotation != null && !nameAnnotation.value().isBlank()) {
+            return nameAnnotation.value();
+        } else if (fieldAnnotation != null && !fieldAnnotation.name().isBlank()) {
+            return fieldAnnotation.name();
+        } else if (staticAnnotation != null && !staticAnnotation.name().isBlank()) {
+            return staticAnnotation.name();
+        } else if (constructorAnnotation != null) {
+            return method.getReturnType().getSimpleName();
+        } else {
+            return method.getName();
+        }
     }
-  }
 
-  private static void checkParamCount(final Method method, final int expected) {
-    if (method.getParameterCount() != expected) {
-      throw new IllegalStateException(
-          "Method " + method.getName() + " must have " + expected + " parameters, found "
-              + method.getParameterCount());
+    private static void checkParamCount(final Method method, final int expected) {
+        if (method.getParameterCount() != expected) {
+            throw new IllegalStateException(
+                    "Method " + method.getName() + " must have " + expected + " parameters, found "
+                            + method.getParameterCount());
+        }
     }
-  }
 
-  private static boolean isEqualsMethod(final Method method) {
-    return "equals".equals(method.getName()) && method.getParameterCount() == 1
-        && method.getParameterTypes()[0] == Object.class;
-  }
-
-  private static boolean isHashCodeMethod(final Method method) {
-    return "hashCode".equals(method.getName()) && method.getParameterCount() == 0;
-  }
-
-  private static boolean isToStringMethod(final Method method) {
-    return "toString".equals(method.getName()) && method.getParameterCount() == 0;
-  }
-
-  private static boolean isEqualsHashOrToStringMethod(final Method method) {
-    return isEqualsMethod(method) || isHashCodeMethod(method) || isToStringMethod(method);
-  }
-
-  private sealed interface Invokable permits HandleInvokable, ReflectionSetterInvokable {
-
-    @Nullable
-    Object invoke(final Object[] args) throws Throwable;
-  }
-
-
-  private record HandleInvokable(MethodHandle handle) implements Invokable {
-
-    @Override
-    public @Nullable Object invoke(final Object[] args) throws Throwable {
-        return handle.invokeExact(args);
+    private static boolean isEqualsMethod(final Method method) {
+        return "equals".equals(method.getName()) && method.getParameterCount() == 1
+                && method.getParameterTypes()[0] == Object.class;
     }
-  }
 
-  private record ReflectionSetterInvokable(Field field, boolean isStatic) implements Invokable {
-
-    @Override
-    public @Nullable Object invoke(Object[] args) throws Throwable {
-      if (isStatic) {
-        SurfUtil.setStaticFinalField(field, args[0]);
-      } else {
-        SurfUtil.setFinalField(field, args[0], args[1]);
-      }
-      return null;
+    private static boolean isHashCodeMethod(final Method method) {
+        return "hashCode".equals(method.getName()) && method.getParameterCount() == 0;
     }
-  }
 
-  private static <T> T sneaky(final ExceptionalSupplier<T> supplier) {
-    try {
-      return supplier.get();
-    } catch (Throwable e) {
-      throw new RuntimeException(e);
+    private static boolean isToStringMethod(final Method method) {
+        return "toString".equals(method.getName()) && method.getParameterCount() == 0;
     }
-  }
 
-  @FunctionalInterface
-  private interface ExceptionalSupplier<T> {
+    private static boolean isEqualsHashOrToStringMethod(final Method method) {
+        return isEqualsMethod(method) || isHashCodeMethod(method) || isToStringMethod(method);
+    }
 
-    T get() throws Throwable;
-  }
+    private sealed interface Invokable permits HandleInvokable, ReflectionSetterInvokable {
+
+        @Nullable
+        Object invoke(final Object[] args) throws Throwable;
+    }
+
+
+    private record HandleInvokable(MethodHandle handle, boolean hasParams) implements Invokable {
+
+        @Override
+        public @Nullable Object invoke(final Object[] args) throws Throwable {
+            if (hasParams) {
+                return handle.invokeExact(args);
+            } else {
+                return handle.invokeExact();
+            }
+        }
+    }
+
+    private record ReflectionSetterInvokable(Field field, boolean isStatic) implements Invokable {
+
+        @Override
+        public @Nullable Object invoke(Object[] args) throws Throwable {
+            if (isStatic) {
+                SurfUtil.setStaticFinalField(field, args[0]);
+            } else {
+                SurfUtil.setFinalField(field, args[0], args[1]);
+            }
+            return null;
+        }
+    }
+
+    private static <T> T sneaky(final ExceptionalSupplier<T> supplier) {
+        try {
+            return supplier.get();
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @FunctionalInterface
+    private interface ExceptionalSupplier<T> {
+
+        T get() throws Throwable;
+    }
 }

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -11,6 +11,7 @@ val snapshot = (findProperty("snapshot") as String).toBooleanStrict()
 plugins {
     `java-library`
     `kotlin-dsl`
+    `java-toolchain-convention`
 
     id("com.gradle.plugin-publish") version "1.3.1"
     kotlin("plugin.serialization")

--- a/surf-api-gradle-plugin/surf-api-processor/build.gradle.kts
+++ b/surf-api-gradle-plugin/surf-api-processor/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
     kotlin("jvm")
     kotlin("plugin.serialization")
     `publish-convention`
+    `java-toolchain-convention`
 }
 
 group = groupId

--- a/surf-api-standalone/build.gradle.kts
+++ b/surf-api-standalone/build.gradle.kts
@@ -32,12 +32,5 @@ dependencies {
     runtimeOnly(libs.flogger.slf4j.backend)
 }
 
-tasks {
-    shadowJar {
-        val relocationPrefix: String by project
-        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt")
-    }
-}
-
 private fun <T : ModuleDependency> T.exclude(provider: Provider<MinimalExternalModuleDependency>) =
     provider.get().module.apply { exclude(group, name) }

--- a/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
+++ b/surf-api-velocity/surf-api-velocity-server/build.gradle.kts
@@ -23,7 +23,6 @@ tasks {
     shadowJar {
         val relocationPrefix: String by project
         relocate("it.unimi.dsi.fastutil", "$relocationPrefix.fastutil")
-        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt")
     }
 }
 


### PR DESCRIPTION
This pull request introduces new features and improvements related to handling NBT (Named Binary Tag) data in commands, adds new NMS (Net Minecraft Server) bridge interfaces, and updates build tooling and dependencies. The most significant changes include the addition of a new command argument type for NBT compounds, new NMS bridge interfaces for command arguments and entity creation, and a new test command for entity summoning with NBT data. There are also updates to Gradle build scripts, including a new Java toolchain convention and dependency updates.

### New NBT Command Argument and Utilities

* Added `AdventureCompoundBinaryTagArgument` and related extension functions to allow commands to accept and parse NBT compound tags as arguments (`AdventureCompoundBinaryTagArgument.kt`).
* Exposed new public API classes for the NBT argument and its extensions in the surf-api-bukkit module (`surf-api-bukkit-api.api`).

### NMS Bridge Interfaces

* Introduced `SurfBukkitNmsCommandArgumentTypesBridge` interface and singleton for accessing NMS-level command argument types, including methods for handling NBT compound tags (`SurfBukkitNmsCommandArgumentTypesBridge.kt`). [[1]](diffhunk://#diff-96a518aef04a005ecb65ec9fa8ab4426cbe24b9a8ed897739f47420c64ab52a2R1-R21) [[2]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR790-R805)
* Added `SurfBukkitNmsEntityBridge` interface and singleton to support creating entities from NBT data (`SurfBukkitNmsEntityBridge.kt`). [[1]](diffhunk://#diff-55cd1bbac857ede62cde84f5bf98c2352d5f40a454f09657b42061adb037d0f3R1-R23) [[2]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR837-R850)

### Test Command Enhancements

* Added `SummonCommandTest` to test entity summoning with NBT data, and registered it in the main test command (`SummonCommandTest.kt`, `SurfApiTestCommand.java`). [[1]](diffhunk://#diff-5c3ff1d09406de572450da039e03827229eee4049b38538332cba8194e2e1e7fR1-R24) [[2]](diffhunk://#diff-f69cd2cb0adaa2bd79ff131627fc55b5ceea20c53e71a3132f602dcbd43f2be2L4-R4) [[3]](diffhunk://#diff-f69cd2cb0adaa2bd79ff131627fc55b5ceea20c53e71a3132f602dcbd43f2be2L41-R30)

### Build System and Dependency Updates

* Introduced a `java-toolchain-convention` Gradle plugin for consistent Java version/toolchain configuration across modules (`java-toolchain-convention.gradle.kts`, `core-convention.gradle.kts`). [[1]](diffhunk://#diff-d7fe2b7db381ec5da4e377ac9adb1e4ee85771b0be9ee101e4843837f3f8235eR1-R18) [[2]](diffhunk://#diff-5a51cb93c1412ae49a475aec86c766d8248bf186e435b09da9e5ec11f674c776R5-R11) [[3]](diffhunk://#diff-5a51cb93c1412ae49a475aec86c766d8248bf186e435b09da9e5ec11f674c776L43-L45)
* Updated Gradle wrapper to 9.4.0-milestone-5 and incremented project version to 1.21.11-2.57.0 (`gradle-wrapper.properties`, `gradle.properties`). [[1]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3) [[2]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L10-R10)
* Added Byte Buddy as a dependency in the versions catalog (`libs.versions.toml`). [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR68) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfR170)

### Utility Improvements

* Added extension properties for chunk X/Z coordinates on `Position` objects in Bukkit utilities for easier chunk math (`bukkit-util.kt`, `surf-api-bukkit-api.api`). [[1]](diffhunk://#diff-97629bc0b80d242d5a4bcb07554f9ace32be612d792728586e9f2402b7673f2cR13) [[2]](diffhunk://#diff-97629bc0b80d242d5a4bcb07554f9ace32be612d792728586e9f2402b7673f2cR119-R128) [[3]](diffhunk://#diff-fb33054296ea62863d7aa5d203e61fb6d56258ad293208252cb4ec0195f4134dR1540-R1542)

These changes improve the flexibility and capability of the command API, especially for advanced use cases involving NBT data and entity manipulation, and modernize the build setup for better maintainability.