### PR TITLE
feat: enhance plugin file generation with JSON output and task improvements

### DIFF
--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
@@ -1,6 +1,5 @@
 package dev.slne.surf.surfapi.gradle.generators
 
-import dev.slne.surf.surfapi.gradle.generators.pluginfiles.CommonPluginFile
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.InternalSerializationApi
 import kotlinx.serialization.KSerializer
@@ -11,35 +10,40 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
+@CacheableTask
 abstract class GeneratePluginFile : DefaultTask() {
     @get:Input
     abstract val fileName: Property<String>
 
-    @get:Nested
-    abstract val pluginFile: Property<CommonPluginFile>
+    @get:Input
+    abstract val pluginFileJson: Property<String>
 
     @get:OutputDirectory
-    abstract val outputDirectory: DirectoryProperty
+    abstract val outputFile: RegularFileProperty
 
     @TaskAction
     fun generate() {
-        val pluginFile = pluginFile.get()
-        if (pluginFile.isApplied()) {
-            val encoded = json.encodeToString(pluginFile)
-            outputDirectory.file(fileName).get().asFile.writeText(encoded)
+        val out = outputFile.get().asFile
+        val json = pluginFileJson.get()
+
+        if (json.isNotBlank()) {
+            out.parentFile.mkdirs()
+            out.writeText(json)
+        } else {
+            if (out.exists()) out.delete()
         }
     }
 
     @OptIn(ExperimentalSerializationApi::class)
     companion object {
-        private val json = Json {
+        val json = Json {
             isLenient = true
             prettyPrint = true
             prettyPrintIndent = "  "

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/LibrariesLoaderGenerator.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/LibrariesLoaderGenerator.kt
@@ -5,10 +5,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputDirectory
-import org.gradle.api.tasks.TaskAction
-import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.register
 import java.io.IOException
 import java.io.InputStreamReader
@@ -19,6 +16,7 @@ import kotlin.reflect.typeOf
 
 const val PaperLibraryLoaderClassName = "PaperLibraryLoader"
 
+@CacheableTask
 abstract class GenerateLibrariesLoaderTask : DefaultTask() {
     @get:Input
     abstract val packageName: Property<String>
@@ -28,6 +26,7 @@ abstract class GenerateLibrariesLoaderTask : DefaultTask() {
 
     @TaskAction
     fun generate() {
+        project.delete(outputDirectory)
         val loader = LibrariesLoaderGenerator.generate(packageName.get())
         loader.writeTo(outputDirectory.get().asFile)
     }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/VelocityPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/VelocityPluginFile.kt
@@ -65,7 +65,7 @@ class VelocityPluginFile(project: Project) : CommonPluginFile() {
     @Nested
     @Optional
     var pluginDependencies: NamedDomainObjectContainer<Dependency> =
-        project.container(Dependency::class.java).apply {
+        project.objects.domainObjectContainer(Dependency::class.java).apply {
             register("surf-api-velocity") {
                 optional = false
             }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
@@ -30,27 +30,28 @@ abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : Commo
             val createdPluginFile = createPluginFile(this)
             extensions.add("${platformName}PluginFile", createdPluginFile)
 
-            val generateTask = tasks.register<GeneratePluginFile>("generate${platformName.uppercaseFirstChar()}PluginFile") {
-                group = "surf-api"
+            val generateTask =
+                tasks.register<GeneratePluginFile>("generate${platformName.uppercaseFirstChar()}PluginFile") {
+                    group = "surf-api"
 
-                fileName.set(pluginFileName)
-                outputDirectory.set(generatedResourcesDirectory)
-                pluginFile.set(provider {
-                    createdPluginFile.setDefaults(target)
-                    createdPluginFile
-                })
+                    fileName.set(pluginFileName)
 
-                doFirst {
-                    if (createdPluginFile.isApplied()) {
-                        createdPluginFile.validate()
-                    } else {
-                        logger.warn(
-                            "Plugin file generation is skipped because the plugin file is not applied. " +
-                                    "Please check if the plugin file is applied in the build.gradle.kts file."
-                        )
-                    }
+                    outputFile.set(generatedResourcesDirectory.map { it.file(pluginFileName) })
+                    pluginFileJson.set(provider {
+                        createdPluginFile.setDefaults(target)
+
+                        if (createdPluginFile.isApplied()) {
+                            createdPluginFile.validate()
+                            GeneratePluginFile.json.encodeToString<CommonPluginFile>(createdPluginFile)
+                        } else {
+                            logger.warn(
+                                "Plugin file generation is skipped because the plugin file is not applied. " +
+                                        "Please check if the plugin file is applied in the build.gradle.kts file."
+                            )
+                            ""
+                        }
+                    })
                 }
-            }
 
             plugins.withType<JavaPlugin> {
                 extensions.getByType<SourceSetContainer>().named(SourceSet.MAIN_SOURCE_SET_NAME) {


### PR DESCRIPTION

This pull request refactors the Gradle plugin file generation logic to improve task cacheability and simplify serialization. The main changes involve switching from domain object serialization to direct JSON handling, updating task input/output properties, and ensuring tasks are cacheable. Additionally, dependency container creation and task registration have been modernized.

**Plugin file generation refactoring:**

* Changed `GeneratePluginFile` to use a JSON string property (`pluginFileJson`) as input and a single file property (`outputFile`) as output, replacing domain object serialization and directory output. Task is now annotated as `@CacheableTask` for improved build caching.
* Updated plugin file generation in `CommonSurfPluginWithPluginFile` to serialize plugin file objects to JSON before passing to the task, and to set the output file property accordingly.

**Task and dependency container improvements:**

* Annotated `GenerateLibrariesLoaderTask` with `@CacheableTask` and added logic to delete the output directory before generation for correctness and cacheability. [[1]](diffhunk://#diff-b4bf4c646008d6d6e4984e8b846a3a842ecea38bb15139d58f8070e2ee77de75R19) [[2]](diffhunk://#diff-b4bf4c646008d6d6e4984e8b846a3a842ecea38bb15139d58f8070e2ee77de75R29)
* Modernized dependency container creation in `VelocityPluginFile` to use `project.objects.domainObjectContainer` instead of the deprecated `project.container`.

**Import and cleanup adjustments:**

* Cleaned up imports in generator files to reflect updated usage and remove unused references. [[1]](diffhunk://#diff-8137193302b02c4e2e478434e63e7f8013d53c953cd187d6be1cb9895876c0c0L3) [[2]](diffhunk://#diff-b4bf4c646008d6d6e4984e8b846a3a842ecea38bb15139d58f8070e2ee77de75L8-R8)