### PR TITLE
Fix/plugin file generation

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.11.8")
+    append("-1.12.0")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
@@ -1,15 +1,8 @@
 package dev.slne.surf.surfapi.gradle.generators
 
 import kotlinx.serialization.ExperimentalSerializationApi
-import kotlinx.serialization.InternalSerializationApi
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
-import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
@@ -47,28 +40,6 @@ abstract class GeneratePluginFile : DefaultTask() {
             isLenient = true
             prettyPrint = true
             prettyPrintIndent = "  "
-        }
-
-        @OptIn(InternalSerializationApi::class)
-        class NamedDomainObjectContainerSerializer<T : Any>(
-            private val dataSerializer: KSerializer<T>,
-        ) : KSerializer<NamedDomainObjectContainer<T>> {
-            override val descriptor: SerialDescriptor = SerialDescriptor(
-                "dev.slne.surf.surfapi.gradle.generators.GeneratePluginFile.NamedDomainObjectContainerSerializer",
-                dataSerializer.descriptor
-            )
-
-            override fun serialize(
-                encoder: Encoder,
-                value: NamedDomainObjectContainer<T>,
-            ) {
-                val values = value.toList()
-                encoder.encodeSerializableValue(ListSerializer(dataSerializer), values)
-            }
-
-            override fun deserialize(decoder: Decoder): NamedDomainObjectContainer<T> {
-                throw UnsupportedOperationException("Deserialization is not supported")
-            }
         }
     }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/CommonPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/CommonPluginFile.kt
@@ -1,18 +1,11 @@
 package dev.slne.surf.surfapi.gradle.generators.pluginfiles
 
-import kotlinx.serialization.Serializable
-import org.gradle.api.Project
 import org.gradle.api.tasks.Internal
 
-@Serializable
 sealed class CommonPluginFile {
 
     @Internal
     internal abstract fun isApplied(): Boolean
-
-    internal open fun setDefaults(project: Project) {
-
-    }
 
     internal open fun validate() {
     }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/HytalePluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/HytalePluginFile.kt
@@ -1,155 +1,65 @@
 package dev.slne.surf.surfapi.gradle.generators.pluginfiles
 
 import dev.slne.surf.surfapi.gradle.platform.invalidPluginFile
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.element
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.encodeStructure
-import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.MapProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
+import javax.inject.Inject
 
-@Serializable(with = HytalePluginFileSerializer::class)
-class HytalePluginFile(project: Project) : CommonPluginFile() {
-    @Input
-    @SerialName("Group")
-    var group: String = "HYS"
+abstract class HytalePluginFile @Inject constructor() : CommonPluginFile() {
+    @get:Input
+    abstract val group: Property<String>
 
-    @Input
-    @SerialName("Id")
-    var id: String? = null
+    @get:Input
+    abstract val id: Property<String>
 
-    @Input
-    @SerialName("Name")
-    var name: String? = null
+    @get:Input
+    abstract val name: Property<String>
 
-    @Input
-    @SerialName("Version")
-    var version: String? = null
+    @get:Input
+    abstract val version: Property<String>
 
-    @Input
-    @SerialName("Description")
-    @Optional
-    var description: String = ""
+    @get:Input
+    abstract val description: Property<String>
 
-    @Input
-    @SerialName("Authors")
-    var authors: List<Author> = mutableListOf()
+    @get:Input
+    abstract val authors: ListProperty<String>
 
-    @Input
-    @SerialName("Website")
-    @Optional
-    var website: String = ""
+    @get:Input
+    abstract val website: Property<String>
 
-    @Input
-    @SerialName("ServerVersion")
-    var serverVersion: String = "*"
+    @get:Input
+    abstract val serverVersion: Property<String>
 
-    @Input
-    @SerialName("DisabledByDefault")
-    var disabledByDefault: Boolean = false
+    @get:Input
+    abstract val disabledByDefault: Property<Boolean>
 
-    @Input
-    @SerialName("Main")
-    var main: String? = null
+    @get:Input
+    abstract val main: Property<String>
 
-    @Input
-    @SerialName("IncludesAssetPack")
-    var includesAssetPack: Boolean = false
+    @get:Input
+    abstract val includesAssetPack: Property<Boolean>
 
-    @Input
-    @SerialName("Dependencies")
-    val dependencies: MutableMap<String, String> = mutableMapOf("HYS:surf-api-hytale-server" to "*")
+    @get:Input
+    abstract val dependencies: MapProperty<String, String>
 
-    @Input
-    @SerialName("OptionalDependencies")
-    val optionalDependencies: MutableMap<String, String> = mutableMapOf()
-
-    @Serializable
-    data class Author(@SerialName("Name") @Input val name: String)
+    @get:Input
+    abstract val optionalDependencies: MapProperty<String, String>
 
     override fun isApplied(): Boolean {
-        return name != null && main != null
-    }
-
-    override fun setDefaults(project: Project) {
-        id = project.name
-        name = project.name
-        version = project.version.toString()
-        description = project.description ?: ""
-        website = project.findProperty("url") as String? ?: ""
+        return main.isPresent
     }
 
     override fun validate() {
-        val id = name ?: invalidPluginFile("Plugin name not set")
+        if (name.orNull.isNullOrBlank()) invalidPluginFile("Plugin name not set")
 
-        if (version.isNullOrBlank()) invalidPluginFile("Plugin version not set")
-        if (main.isNullOrBlank()) invalidPluginFile("Main class not set")
+        if (version.orNull.isNullOrBlank()) invalidPluginFile("Plugin version not set")
+        if (main.orNull.isNullOrBlank()) invalidPluginFile("Main class not set")
 
-        for ((dependency, version) in optionalDependencies) {
+        optionalDependencies.orNull?.forEach { (dependency, version) ->
             if (dependency.isBlank()) invalidPluginFile("Dependency id not set")
             if (version.isBlank()) invalidPluginFile("Dependency '$dependency' version not set")
         }
-    }
-}
-
-object HytalePluginFileSerializer : KSerializer<HytalePluginFile> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("HytalePluginFile") {
-        element<String>("Group")
-        element<String>("Name")
-        element<String>("Version")
-        element<String>("Description")
-        element<List<HytalePluginFile.Author>>("Authors")
-        element<String>("Website")
-        element<String>("ServerVersion")
-        element<Boolean>("DisabledByDefault")
-        element<String>("Main")
-        element<Boolean>("IncludesAssetPack")
-        element<Map<String, String>>("Dependencies")
-        element<Map<String, String>>("PluginDependencies")
-    }
-
-    override fun serialize(encoder: Encoder, value: HytalePluginFile) {
-        encoder.encodeStructure(descriptor) {
-            encodeStringElement(descriptor, 0, value.group ?: "")
-            encodeStringElement(descriptor, 1, value.name ?: "")
-            encodeStringElement(descriptor, 2, value.version ?: "")
-            encodeStringElement(descriptor, 3, value.description ?: "")
-            encodeSerializableElement(
-                descriptor,
-                4,
-                ListSerializer(HytalePluginFile.Author.serializer()),
-                value.authors
-            )
-            encodeStringElement(descriptor, 5, value.website ?: "")
-            encodeStringElement(descriptor, 6, value.serverVersion ?: "")
-            encodeBooleanElement(descriptor, 7, value.disabledByDefault)
-            encodeStringElement(descriptor, 8, value.main ?: "")
-            encodeBooleanElement(descriptor, 9, value.includesAssetPack)
-            encodeSerializableElement(
-                descriptor,
-                10,
-                MapSerializer(String.serializer(), String.serializer()),
-                value.dependencies
-            )
-            encodeSerializableElement(
-                descriptor,
-                11,
-                MapSerializer(String.serializer(), String.serializer()),
-                value.optionalDependencies
-            )
-        }
-    }
-
-    override fun deserialize(decoder: Decoder): HytalePluginFile {
-        throw NotImplementedError("Deserialization is not supported for HytalePluginFile")
     }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/VelocityPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/VelocityPluginFile.kt
@@ -1,168 +1,77 @@
 package dev.slne.surf.surfapi.gradle.generators.pluginfiles
 
-import dev.slne.surf.surfapi.gradle.generators.GeneratePluginFile.Companion.NamedDomainObjectContainerSerializer
-import dev.slne.surf.surfapi.gradle.generators.pluginfiles.VelocityPluginFile.Dependency
 import dev.slne.surf.surfapi.gradle.platform.invalidPluginFile
-import dev.slne.surf.surfapi.gradle.platform.velocity.VelocitySurfExtension
-import kotlinx.serialization.*
-import kotlinx.serialization.builtins.ArraySerializer
-import kotlinx.serialization.builtins.ListSerializer
-import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.descriptors.buildClassSerialDescriptor
-import kotlinx.serialization.descriptors.element
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import kotlinx.serialization.encoding.encodeStructure
 import org.gradle.api.NamedDomainObjectContainer
-import org.gradle.api.Project
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
-import org.gradle.kotlin.dsl.findByType
+import org.gradle.kotlin.dsl.domainObjectContainer
 import org.intellij.lang.annotations.Pattern
 import org.intellij.lang.annotations.RegExp
+import javax.inject.Inject
 
 @RegExp
 private const val ID_REGEX = "[a-z][a-z0-9-_]{0,63}"
+private val idRegex = ID_REGEX.toRegex()
 
-@Serializable(with = VelocityPluginFileSerializer::class)
-class VelocityPluginFile(project: Project) : CommonPluginFile() {
-    @Transient
-    private val idRegex = ID_REGEX.toRegex()
+abstract class VelocityPluginFile @Inject constructor(
+    objects: ObjectFactory
+) : CommonPluginFile() {
+    @get:Pattern(ID_REGEX)
+    @get:Input
+    abstract val id: Property<String>
 
-    @Pattern(ID_REGEX)
-    @Input
-    @Optional
-    var id: String? = null
+    @get:Input
+    abstract val main: Property<String>
 
-    @Input
-    @Optional
-    var main: String? = null
+    @get:Input
+    abstract val name: Property<String>
 
-    @Input
-    @Optional
-    var name: String? = null
+    @get:Input
+    abstract val version: Property<String>
 
-    @Input
-    @Optional
-    var version: String? = null
+    @get:Input
+    abstract val description: Property<String>
 
-    @Input
-    @Optional
-    var description: String? = null
+    @get:Input
+    abstract val url: Property<String>
 
-    @Input
-    @Optional
-    var url: String? = null
+    @get:Input
+    abstract val authors: ListProperty<String>
 
-    @Input
-    @Optional
-    var authors: List<String>? = null
+    @get:Nested
+    val pluginDependencies: NamedDomainObjectContainer<Dependency> = objects.domainObjectContainer(Dependency::class)
 
+    abstract class Dependency @Inject constructor(
+        @get:Input val name: String
+    ) {
+        @get:Input
+        abstract val optional: Property<Boolean>
 
-    @Serializable(with = NamedDomainObjectContainerSerializer::class)
-    @Nested
-    @Optional
-    var pluginDependencies: NamedDomainObjectContainer<Dependency> =
-        project.objects.domainObjectContainer(Dependency::class.java).apply {
-            register("surf-api-velocity") {
-                optional = false
-            }
+        @get:Input
+        internal abstract val enabled: Property<Boolean>
 
-            project.afterEvaluate {
-                project.extensions.findByType<VelocitySurfExtension>()?.let { extension ->
-                    if (extension.coreModule.isPresent) {
-                        register("surf-core-velocity") {
-                            optional = false
-                        }
-                    }
-
-                    if (extension.withSurfRedis.get() && !extension.surfRedisRelocation.isPresent) {
-                        register("surf-redis-velocity") {
-                            optional = false
-                        }
-                    }
-                }
-            }
+        init {
+            optional.convention(false)
+            enabled.convention(true)
         }
-
-    @Serializable
-    data class Dependency(@SerialName("id") @Input val name: String) {
-        @OptIn(ExperimentalSerializationApi::class)
-        @EncodeDefault
-        @Input
-        var optional: Boolean = false
     }
 
     override fun isApplied(): Boolean {
-        return id != null && main != null
-    }
-
-    override fun setDefaults(project: Project) {
-        id = project.name
-        version = project.version.toString()
-        description = project.description
-        url = project.findProperty("url") as String?
+        return main.isPresent
     }
 
     override fun validate() {
-        val id = id ?: invalidPluginFile("Plugin id not set")
+        val id = id.orNull ?: invalidPluginFile("Plugin id not set")
         if (!(idRegex.matches(id))) invalidPluginFile("Invalid plugin id! Should match $idRegex")
 
-        if (version.isNullOrBlank()) invalidPluginFile("Plugin version not set")
-        if (main.isNullOrBlank()) invalidPluginFile("Main class not set")
+        if (version.orNull.isNullOrBlank()) invalidPluginFile("Plugin version not set")
+        if (main.orNull.isNullOrBlank()) invalidPluginFile("Main class not set")
 
         for (dependency in pluginDependencies) {
             if (dependency.name.isBlank()) invalidPluginFile("Dependency id not set")
         }
-    }
-}
-
-object VelocityPluginFileSerializer : KSerializer<VelocityPluginFile> {
-    override val descriptor: SerialDescriptor = buildClassSerialDescriptor("VelocityPluginFile") {
-        element<String>("id", isOptional = true)
-        element<String>("main", isOptional = true)
-        element<String>("name", isOptional = true)
-        element<String>("version", isOptional = true)
-        element<String>("description", isOptional = true)
-        element<String>("url", isOptional = true)
-        element<List<String>>("authors", isOptional = true)
-        element<Array<Dependency>>("dependencies", isOptional = true)
-    }
-
-    override fun serialize(encoder: Encoder, value: VelocityPluginFile) {
-        encoder.encodeStructure(descriptor) {
-            value.id?.let { encodeStringElement(descriptor, 0, it) }
-            value.main?.let { encodeStringElement(descriptor, 1, it) }
-            value.name?.let { encodeStringElement(descriptor, 2, it) }
-            value.version?.let { encodeStringElement(descriptor, 3, it) }
-            value.description?.let { encodeStringElement(descriptor, 4, it) }
-            value.url?.let { encodeStringElement(descriptor, 5, it) }
-            value.authors?.let {
-                encodeSerializableElement(
-                    descriptor,
-                    6,
-                    ListSerializer(String.serializer()),
-                    it
-                )
-            }
-
-            val dep = value.pluginDependencies
-            val namer = dep.namer
-
-            dep.associateBy { namer.determineName(it) }
-
-            encodeSerializableElement(
-                descriptor,
-                7,
-                ArraySerializer(Dependency.serializer()),
-                value.pluginDependencies.toTypedArray()
-            )
-        }
-    }
-
-    override fun deserialize(decoder: Decoder): VelocityPluginFile {
-        throw UnsupportedOperationException("Deserialization is not supported")
     }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/HytalePluginFileDto.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/HytalePluginFileDto.kt
@@ -1,0 +1,69 @@
+package dev.slne.surf.surfapi.gradle.generators.pluginfiles.dto
+
+import dev.slne.surf.surfapi.gradle.generators.pluginfiles.HytalePluginFile
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class HytalePluginFileDto(
+    @SerialName("Group")
+    val group: String,
+
+    @SerialName("Id")
+    val id: String? = null,
+
+    @SerialName("Name")
+    val name: String,
+
+    @SerialName("Version")
+    val version: String,
+
+    @SerialName("Description")
+    val description: String,
+
+    @SerialName("Authors")
+    val authors: List<AuthorDto>,
+
+    @SerialName("Website")
+    val website: String,
+
+    @SerialName("ServerVersion")
+    val serverVersion: String,
+
+    @SerialName("DisabledByDefault")
+    val disabledByDefault: Boolean,
+
+    @SerialName("Main")
+    val main: String,
+
+    @SerialName("IncludesAssetPack")
+    val includesAssetPack: Boolean,
+
+    @SerialName("Dependencies")
+    val dependencies: Map<String, String>,
+
+    @SerialName("OptionalDependencies")
+    val optionalDependencies: Map<String, String>,
+) {
+    @Serializable
+    data class AuthorDto(
+        val name: String,
+    )
+
+    companion object {
+        fun fromFile(file: HytalePluginFile) = HytalePluginFileDto(
+            group = file.group.get(),
+            name = file.name.get(),
+            version = file.version.get(),
+            description = file.description.get(),
+            authors = file.authors.getOrElse(emptyList()).map { AuthorDto(it) },
+            website = file.website.get(),
+            serverVersion = file.serverVersion.get(),
+            disabledByDefault = file.disabledByDefault.get(),
+            main = file.main.get(),
+            includesAssetPack = file.includesAssetPack.get(),
+            dependencies = file.dependencies.get(),
+            optionalDependencies = file.optionalDependencies.get()
+        )
+    }
+}

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/VelocityPluginFileDto.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/VelocityPluginFileDto.kt
@@ -1,0 +1,41 @@
+package dev.slne.surf.surfapi.gradle.generators.pluginfiles.dto
+
+import dev.slne.surf.surfapi.gradle.generators.pluginfiles.VelocityPluginFile
+import kotlinx.serialization.Serializable
+
+
+@Serializable
+data class VelocityPluginFileDto(
+    val id: String? = null,
+    val main: String? = null,
+    val name: String? = null,
+    val version: String? = null,
+    val description: String? = null,
+    val url: String? = null,
+    val authors: List<String>? = null,
+    val dependencies: List<DependencyDto>? = null,
+) {
+    @Serializable
+    data class DependencyDto(
+        val id: String,
+        val optional: Boolean,
+    )
+
+
+    companion object {
+        fun fromFile(file: VelocityPluginFile) = VelocityPluginFileDto(
+            id = file.id.orNull,
+            main = file.main.orNull,
+            name = file.name.orNull,
+            version = file.version.orNull,
+            description = file.description.orNull,
+            url = file.url.orNull,
+            authors = file.authors.orNull,
+            dependencies = file.pluginDependencies
+                .filter { it.enabled.get() }
+                .map { DependencyDto(it.name, it.optional.get()) }
+        )
+    }
+}
+
+

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPlugin.kt
@@ -9,7 +9,6 @@ import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPluginExtension
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.tasks.compile.JavaCompile
@@ -40,11 +39,10 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
     private val relocations = mutableMapOf<String, String>()
     private val dependencyDependentRelocations = mutableMapOf<String, MutableMap<String, String>>()
 
-    protected abstract fun createExtension(objects: ObjectFactory, project: Project): E
+    protected abstract val extensionClass: Class<E>
 
     override fun apply(target: Project) = with(target) {
-        val extension = createExtension(objects, this)
-        extensions.add("surf${platformName.replaceFirstChar { it.uppercase() }}Api", extension)
+        val extension = extensions.create("surf${platformName.replaceFirstChar { it.uppercase() }}Api", extensionClass)
 
         applyRepositories()
         applyPlugins()

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.surfapi.gradle.platform.common
 import dev.slne.surf.surfapi.gradle.generators.GeneratePluginFile
 import dev.slne.surf.surfapi.gradle.generators.pluginfiles.CommonPluginFile
 import dev.slne.surf.surfapi.gradle.platform.SurfApiPlatform
+import kotlinx.serialization.SerializationStrategy
 import org.gradle.api.Project
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
@@ -12,13 +13,16 @@ import org.gradle.kotlin.dsl.register
 import org.gradle.kotlin.dsl.support.uppercaseFirstChar
 import org.gradle.kotlin.dsl.withType
 
-abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : CommonPluginFile>(
+abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : CommonPluginFile, D>(
     platformName: String,
     platform: SurfApiPlatform,
     private val pluginFileName: String,
 ) : CommonSurfPlugin<E>(platformName, platform) {
 
+    protected abstract val dtoSerializer: SerializationStrategy<D>
+
     protected abstract fun createPluginFile(project: Project): F
+    protected abstract fun createPluginFileDto(pluginFile: F): D
 
     override fun apply(target: Project) {
         super.apply(target)
@@ -35,14 +39,12 @@ abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : Commo
                     group = "surf-api"
 
                     fileName.set(pluginFileName)
-
                     outputFile.set(generatedResourcesDirectory.map { it.file(pluginFileName) })
                     pluginFileJson.set(provider {
-                        createdPluginFile.setDefaults(target)
-
                         if (createdPluginFile.isApplied()) {
                             createdPluginFile.validate()
-                            GeneratePluginFile.json.encodeToString<CommonPluginFile>(createdPluginFile)
+                            val dto = createPluginFileDto(createdPluginFile)
+                            GeneratePluginFile.json.encodeToString(dtoSerializer, dto)
                         } else {
                             logger.warn(
                                 "Plugin file generation is skipped because the plugin file is not applied. " +

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/core/CoreSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/core/CoreSurfPlugin.kt
@@ -3,7 +3,6 @@ package dev.slne.surf.surfapi.gradle.platform.core
 import dev.slne.surf.surfapi.gradle.platform.SurfApiPlatform
 import dev.slne.surf.surfapi.gradle.platform.common.CommonSurfPlugin
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
 
 internal abstract class AbstractCoreSurfPlugin<E : CoreSurfExtension>(
     platformName: String, platform: SurfApiPlatform,
@@ -24,6 +23,5 @@ internal abstract class AbstractCoreSurfPlugin<E : CoreSurfExtension>(
 
 internal class CoreSurfPlugin :
     AbstractCoreSurfPlugin<CoreSurfExtension>("core", SurfApiPlatform.CORE) {
-    override fun createExtension(objects: ObjectFactory, project: Project) =
-        CoreSurfExtension(objects)
+    override val extensionClass = CoreSurfExtension::class.java
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/hytale/HytaleSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/hytale/HytaleSurfPlugin.kt
@@ -2,22 +2,23 @@ package dev.slne.surf.surfapi.gradle.platform.hytale
 
 import dev.slne.surf.surfapi.gradle.generated.Constants
 import dev.slne.surf.surfapi.gradle.generators.pluginfiles.HytalePluginFile
+import dev.slne.surf.surfapi.gradle.generators.pluginfiles.dto.HytalePluginFileDto
 import dev.slne.surf.surfapi.gradle.platform.SurfApiPlatform
 import dev.slne.surf.surfapi.gradle.platform.common.CommonSurfPluginWithPluginFile
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
 import org.jetbrains.kotlin.gradle.utils.COMPILE_ONLY
 
 internal class HytaleSurfPlugin :
-    CommonSurfPluginWithPluginFile<HytaleSurfExtension, HytalePluginFile>(
+    CommonSurfPluginWithPluginFile<HytaleSurfExtension, HytalePluginFile, HytalePluginFileDto>(
         "hytale",
         SurfApiPlatform.HYTALE,
         "manifest.json"
     ) {
 
-    override fun createExtension(objects: ObjectFactory, project: Project) =
-        HytaleSurfExtension(project, objects)
+    override val extensionClass = HytaleSurfExtension::class.java
+    override val dtoSerializer = HytalePluginFileDto.serializer()
 
     init {
         "it.unimi.dsi.fastutil" relocatesTo "fastutil"
@@ -29,5 +30,24 @@ internal class HytaleSurfPlugin :
         }
     }
 
-    override fun createPluginFile(project: Project) = HytalePluginFile(project)
+    override fun createPluginFile(
+        project: Project
+    ) = project.extensions.create<HytalePluginFile>("hytalePluginFile").apply {
+        group.convention("HYS")
+        id.convention(project.name.lowercase())
+        name.convention(project.provider { project.name })
+        version.convention(project.provider { project.version.toString() })
+        description.convention(project.provider { project.description ?: "" })
+        authors.convention(mutableListOf("SLNE Development"))
+        website.convention(project.providers.gradleProperty("url").orElse(""))
+        serverVersion.convention("*")
+        disabledByDefault.convention(false)
+        includesAssetPack.convention(false)
+        dependencies.convention(mutableMapOf("HYS:surf-api-hytale-server" to "*"))
+        optionalDependencies.convention(mutableMapOf())
+    }
+
+    override fun createPluginFileDto(pluginFile: HytalePluginFile): HytalePluginFileDto {
+        return HytalePluginFileDto.fromFile(pluginFile)
+    }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
@@ -7,7 +7,6 @@ import dev.slne.surf.surfapi.gradle.util.registerRequired
 import net.minecrell.pluginyml.GeneratePluginDescription
 import net.minecrell.pluginyml.paper.PaperPluginDescription
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
@@ -19,6 +18,8 @@ import xyz.jpenilla.runpaper.task.RunServer
 
 internal class PaperPluginSurfPlugin :
     AbstractPaperSurfPlugin<PaperPluginSurfExtension>("paperPlugin") {
+
+    override val extensionClass = PaperPluginSurfExtension::class.java
 
     init {
         addRelocationsForDependency(
@@ -94,9 +95,6 @@ internal class PaperPluginSurfPlugin :
             }
         }
     }
-
-    override fun createExtension(objects: ObjectFactory, project: Project) =
-        PaperPluginSurfExtension(objects)
 
     override fun Project.applyPlugins0() {
         paperPlugins.forEach { plugin ->

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/raw/RawPaperSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/paper/raw/RawPaperSurfPlugin.kt
@@ -1,9 +1,7 @@
 package dev.slne.surf.surfapi.gradle.platform.paper.raw
 
 import dev.slne.surf.surfapi.gradle.platform.paper.AbstractPaperSurfPlugin
-import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
 
 internal class RawPaperSurfPlugin : AbstractPaperSurfPlugin<RawPaperSurfExtension>("rawPaper") {
-    override fun createExtension(objects: ObjectFactory, project: Project) = RawPaperSurfExtension(objects)
+    override val extensionClass = RawPaperSurfExtension::class.java
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/standalone/StandaloneSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/standalone/StandaloneSurfPlugin.kt
@@ -2,10 +2,8 @@ package dev.slne.surf.surfapi.gradle.platform.standalone
 
 import dev.slne.surf.surfapi.gradle.platform.SurfApiPlatform
 import dev.slne.surf.surfapi.gradle.platform.core.AbstractCoreSurfPlugin
-import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
 
 internal class StandaloneSurfPlugin :
     AbstractCoreSurfPlugin<StandaloneSurfExtension>("standalone", SurfApiPlatform.STANDALONE) {
-    override fun createExtension(objects: ObjectFactory, project: Project) = StandaloneSurfExtension(objects)
+    override val extensionClass = StandaloneSurfExtension::class.java
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/velocity/VelocitySurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/velocity/VelocitySurfPlugin.kt
@@ -2,26 +2,28 @@ package dev.slne.surf.surfapi.gradle.platform.velocity
 
 import dev.slne.surf.surfapi.gradle.generated.Constants
 import dev.slne.surf.surfapi.gradle.generators.pluginfiles.VelocityPluginFile
+import dev.slne.surf.surfapi.gradle.generators.pluginfiles.dto.VelocityPluginFileDto
 import dev.slne.surf.surfapi.gradle.platform.SurfApiPlatform
 import dev.slne.surf.surfapi.gradle.platform.common.CommonSurfPluginWithPluginFile
 import org.gradle.api.Project
-import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.create
 import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.invoke
 import org.jetbrains.kotlin.gradle.utils.COMPILE_ONLY
 
 internal class VelocitySurfPlugin :
-    CommonSurfPluginWithPluginFile<VelocitySurfExtension, VelocityPluginFile>(
+    CommonSurfPluginWithPluginFile<VelocitySurfExtension, VelocityPluginFile, VelocityPluginFileDto>(
         "velocity",
         SurfApiPlatform.VELOCITY,
         "velocity-plugin.json"
     ) {
 
-    override fun createExtension(objects: ObjectFactory, project: Project) =
-        VelocitySurfExtension(project, objects)
-
     init {
         "it.unimi.dsi.fastutil" relocatesTo "fastutil"
     }
+
+    override val extensionClass = VelocitySurfExtension::class.java
+    override val dtoSerializer = VelocityPluginFileDto.serializer()
 
     override fun Project.configure0() {
         dependencies {
@@ -30,5 +32,41 @@ internal class VelocitySurfPlugin :
         }
     }
 
-    override fun createPluginFile(project: Project) = VelocityPluginFile(project)
+    override fun createPluginFile(
+        project: Project
+    ) = project.extensions.create<VelocityPluginFile>("velocityPluginFile").apply {
+        id.convention(project.name.lowercase())
+        name.convention(project.provider { project.name })
+        version.convention(project.provider { project.version.toString() })
+        description.convention(project.provider { project.description ?: "" })
+        url.convention(project.providers.gradleProperty("url"))
+
+        val ext = project.extensions.getByType(VelocitySurfExtension::class.java)
+        val coreEnabled = ext.coreModule.map { true }.orElse(false)
+        val surfRedisRelocationPresent = ext.surfRedisRelocation.map { true }.orElse(false)
+        val redisEnabled = ext.withSurfRedis.zip(surfRedisRelocationPresent) { withRedis, relocPresent ->
+            withRedis && !relocPresent
+        }
+
+        pluginDependencies {
+            register("surf-api-velocity") {
+                optional.convention(false)
+                enabled.convention(true)
+            }
+
+            register("surf-core-velocity") {
+                optional.convention(false)
+                enabled.convention(coreEnabled)
+            }
+
+            register("surf-redis-velocity") {
+                optional.convention(false)
+                enabled.convention(redisEnabled)
+            }
+        }
+    }
+
+    override fun createPluginFileDto(pluginFile: VelocityPluginFile): VelocityPluginFileDto {
+        return VelocityPluginFileDto.fromFile(pluginFile)
+    }
 }


### PR DESCRIPTION
This pull request refactors the plugin file system in the Gradle plugin to improve type safety, serialization, and maintainability. The main changes include replacing direct serialization of plugin file classes with dedicated DTOs, updating property management to use Gradle's `Property` and `ListProperty` APIs, and simplifying the plugin extension and validation logic.

**Plugin file and serialization refactor:**

- Introduced new DTO classes for plugin files (`HytalePluginFileDto` and `VelocityPluginFileDto`) to handle serialization, replacing custom serializers and direct annotation-based serialization in plugin file classes. (`surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/HytalePluginFileDto.kt` [[1]](diffhunk://#diff-87b6957289676833a7a6da69313c480b4b6ae65aebf866ef152597224d1074fdR1-R69) `surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/dto/VelocityPluginFileDto.kt` [[2]](diffhunk://#diff-c573fa241bd28418689018e2cfdbd94604f43f4d27652ac62572790589a8b405R1-R41)
- Removed custom serializers and serialization annotations from `HytalePluginFile` and `VelocityPluginFile`, and migrated their properties to use Gradle's `Property`, `ListProperty`, and `MapProperty` APIs for better integration with Gradle's configuration and task system. (`surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/HytalePluginFile.kt` [[1]](diffhunk://#diff-51f8a7aa3388a99ba426d4cb19ff7da0526a48878ae3ba7a0ed1bb29101a7471L4-L155) `surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/VelocityPluginFile.kt` [[2]](diffhunk://#diff-847435aeb0aebb776488ba2f1871b425455319339611232800bb4a320ce49890L3-L168)
- Updated the plugin infrastructure to require a DTO serializer and a method to convert plugin files to DTOs, enabling a more robust and explicit serialization pipeline. (`surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt` [[1]](diffhunk://#diff-813959006b04292ad6ae48f508e25c057ec2bcd5a4fd655c173a8c86c966fe02R6) [[2]](diffhunk://#diff-813959006b04292ad6ae48f508e25c057ec2bcd5a4fd655c173a8c86c966fe02L15-R25)

**Codebase simplification and cleanup:**

- Removed unused imports and obsolete serialization logic from several files, including `GeneratePluginFile.kt`, `CommonPluginFile.kt`, and others, reducing complexity and technical debt. (`surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt` [[1]](diffhunk://#diff-8137193302b02c4e2e478434e63e7f8013d53c953cd187d6be1cb9895876c0c0L4-L12) [[2]](diffhunk://#diff-8137193302b02c4e2e478434e63e7f8013d53c953cd187d6be1cb9895876c0c0L51-L72) `surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/pluginfiles/CommonPluginFile.kt` [[3]](diffhunk://#diff-8f4aeca8294c3b0a054807c091b3167ad99b678d7a3a21f72fcdb95e2adeee24L3-L16)
- Refactored plugin extension creation to use class references instead of factory methods, simplifying extension registration in the plugin system. (`surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPlugin.kt` [[1]](diffhunk://#diff-e6cc100f619714ec025cdf0a9d205bea2353edd92680649ec812913b37b784d6L12) [[2]](diffhunk://#diff-e6cc100f619714ec025cdf0a9d205bea2353edd92680649ec812913b37b784d6L43-R45)

**Version update:**

- Bumped the plugin version suffix from `1.11.8` to `1.12.0` in the build file. (`surf-api-gradle-plugin/build.gradle.kts` [surf-api-gradle-plugin/build.gradle.ktsL24-R24](diffhunk://#diff-2e36ad9dcce88f8b5727df509328b34dae36f5121e3c833790b233c87a79c54eL24-R24))