### PR TITLE
Fix/plugin file generation

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.12.0")
+    append("-1.12.1")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
@@ -32,7 +32,6 @@ abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : Commo
                 layout.buildDirectory.dir("generated/surf-api/$platformName")
 
             val createdPluginFile = createPluginFile(this)
-            extensions.add("${platformName}PluginFile", createdPluginFile)
 
             val generateTask =
                 tasks.register<GeneratePluginFile>("generate${platformName.uppercaseFirstChar()}PluginFile") {


### PR DESCRIPTION
This pull request contains two minor changes: a version bump and the removal of an unnecessary extension registration. These updates help keep the project versioning accurate and streamline the plugin file generation process.

Versioning update:

* Updated the plugin version suffix in `build.gradle.kts` from `-1.12.0` to `-1.12.1` to reflect the new release version.

Code simplification:

* Removed the redundant `extensions.add` call for the plugin file in `CommonSurfPluginWithPluginFile.kt`, as it is no longer needed for plugin file generation.