### PR TITLE
Fix/plugin file generation

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.12.1")
+    append("-1.12.2")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
@@ -7,7 +7,7 @@ import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
@@ -18,7 +18,7 @@ abstract class GeneratePluginFile : DefaultTask() {
     @get:Input
     abstract val pluginFileJson: Property<String>
 
-    @get:OutputDirectory
+    @get:OutputFile
     abstract val outputFile: RegularFileProperty
 
     @TaskAction


### PR DESCRIPTION
This pull request updates the versioning scheme of the Gradle plugin and corrects the output annotation for the plugin file generation task. The main changes include incrementing the plugin's patch version and ensuring that the plugin file task is properly marked as producing a single output file rather than a directory.

Versioning update:

* Bumped the plugin version suffix from `-1.12.1` to `-1.12.2` in `build.gradle.kts` to reflect a new patch release.

Gradle task annotation fix:

* Changed the annotation for the `outputFile` property in `GeneratePluginFile` from `@OutputDirectory` to `@OutputFile`, correctly indicating that the task produces a single file output instead of a directory. [[1]](diffhunk://#diff-8137193302b02c4e2e478434e63e7f8013d53c953cd187d6be1cb9895876c0c0L10-R10) [[2]](diffhunk://#diff-8137193302b02c4e2e478434e63e7f8013d53c953cd187d6be1cb9895876c0c0L21-R21)