### PR TITLE
Fix/plugin file generation

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -21,7 +21,7 @@ plugins {
 group = groupId
 version = buildString {
     append(mcVersion)
-    append("-1.12.2")
+    append("-1.12.3")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/generators/GeneratePluginFile.kt
@@ -3,35 +3,36 @@ package dev.slne.surf.surfapi.gradle.generators
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import org.gradle.api.DefaultTask
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.TaskAction
 
 @CacheableTask
 abstract class GeneratePluginFile : DefaultTask() {
     @get:Input
-    abstract val fileName: Property<String>
-
-    @get:Input
     abstract val pluginFileJson: Property<String>
 
-    @get:OutputFile
-    abstract val outputFile: RegularFileProperty
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    @get:Input
+    abstract val fileName: Property<String>
 
     @TaskAction
     fun generate() {
-        val out = outputFile.get().asFile
+        val outFile = outputDir.file(fileName).get().asFile
         val json = pluginFileJson.get()
 
-        if (json.isNotBlank()) {
-            out.parentFile.mkdirs()
-            out.writeText(json)
-        } else {
-            if (out.exists()) out.delete()
+        if (json.isBlank()) {
+            if (outFile.exists()) outFile.delete()
+            return
         }
+
+        outFile.parentFile.mkdirs()
+        outFile.writeText(json)
     }
 
     @OptIn(ExperimentalSerializationApi::class)

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/surfapi/gradle/platform/common/CommonSurfPluginWithPluginFile.kt
@@ -38,7 +38,7 @@ abstract class CommonSurfPluginWithPluginFile<E : CommonSurfExtension, F : Commo
                     group = "surf-api"
 
                     fileName.set(pluginFileName)
-                    outputFile.set(generatedResourcesDirectory.map { it.file(pluginFileName) })
+                    outputDir.set(generatedResourcesDirectory)
                     pluginFileJson.set(provider {
                         if (createdPluginFile.isApplied()) {
                             createdPluginFile.validate()


### PR DESCRIPTION
This pull request updates the `surf-api-gradle-plugin` to improve plugin file generation and bump the plugin version. The main changes involve switching the plugin file generation task from outputting a single file to specifying an output directory and file name separately, which simplifies configuration and improves flexibility.

Version update:

* Bumped the plugin version from `1.12.2` to `1.12.3` in `build.gradle.kts` for improved release tracking.

Plugin file generation improvements:

* Refactored the `GeneratePluginFile` task to use an output directory (`DirectoryProperty`) and file name (`Property<String>`) instead of an output file (`RegularFileProperty`). This change streamlines how the generated plugin file is specified and written.
* Updated the plugin file generation logic in `CommonSurfPluginWithPluginFile.kt` to set the output directory instead of the output file, aligning with the refactored task interface.