### PR TITLE
fix: correct ConditionalOnMissingComponent inheritance check

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.59.1
+version=1.21.11-2.59.2
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-core/surf-api-core-server/src/main/kotlin/dev/slne/surf/surfapi/core/server/component/ComponentService.kt
+++ b/surf-api-core/surf-api-core-server/src/main/kotlin/dev/slne/surf/surfapi/core/server/component/ComponentService.kt
@@ -233,7 +233,7 @@ abstract class ComponentService {
         if (!evaluateEnvironmentConditions(componentMeta, logger)) return null
 
         // Evaluate @ConditionalOnMissingComponent
-        if (!evaluateMissingComponentConditions(componentMeta, loadedComponents, logger)) return null
+        if (!evaluateMissingComponentConditions(componentMeta, loadedComponents, classLoader, logger)) return null
 
         // Evaluate @ConditionalOnProperty
         if (!evaluatePropertyConditions(owner, componentMeta, logger)) return null
@@ -291,13 +291,19 @@ abstract class ComponentService {
     private fun evaluateMissingComponentConditions(
         componentMeta: PluginComponentMeta.Component,
         loadedComponents: List<ComponentEntry>,
+        classLoader: ClassLoader,
         logger: ComponentLogger
     ): Boolean {
         for (missingComponent in componentMeta.conditionalOnMissingComponents) {
             val isLoaded = loadedComponents.any { (component) ->
-                val kClass = component::class
-                val className = kClass.qualifiedName ?: kClass.java.name
-                className == missingComponent
+                val loadedComponentClass = component.javaClass
+                val missingComponentClass = try {
+                    Class.forName(missingComponent, false, classLoader)
+                } catch (_: ClassNotFoundException) {
+                    null
+                }
+
+                missingComponentClass != null && missingComponentClass.isAssignableFrom(loadedComponentClass)
             }
             if (isLoaded) {
                 logger.debug(


### PR DESCRIPTION
Fix isAssignableFrom direction in evaluateMissingComponentConditions to properly check if loaded components are assignable to the missing component type. Previously checked the inverse relationship, causing incorrect conditional component loading.

Also refactored to use Class.forName with the component's classLoader instead of Kotlin reflection for more reliable class comparison across different plugin classloaders.