### PR TITLE
refactor: simplify owner validation in VelocityComponentService

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.59.2
+version=1.21.11-2.59.3
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-velocity/surf-api-velocity-server/src/main/kotlin/dev/slne/surf/surfapi/velocity/server/component/VelocityComponentService.kt
+++ b/surf-api-velocity/surf-api-velocity-server/src/main/kotlin/dev/slne/surf/surfapi/velocity/server/component/VelocityComponentService.kt
@@ -1,12 +1,14 @@
 package dev.slne.surf.surfapi.velocity.server.component
 
 import com.google.auto.service.AutoService
+import com.velocitypowered.api.plugin.PluginContainer
 import dev.slne.surf.surfapi.core.server.component.ComponentService
 import dev.slne.surf.surfapi.velocity.server.velocityMain
 import net.kyori.adventure.text.logger.slf4j.ComponentLogger
 import java.nio.file.Path
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
 import kotlin.io.path.Path
-import kotlin.jvm.optionals.getOrNull
 
 @AutoService(ComponentService::class)
 class VelocityComponentService : ComponentService() {
@@ -15,7 +17,8 @@ class VelocityComponentService : ComponentService() {
     }
 
     override fun getClassloader(owner: Any): ClassLoader {
-        return getInstanceFromOwner(owner).javaClass.classLoader
+        ensureOwnerIsPluginContainer(owner)
+        return owner.javaClass.classLoader
     }
 
     override fun isPluginLoaded(pluginId: String): Boolean {
@@ -23,18 +26,21 @@ class VelocityComponentService : ComponentService() {
     }
 
     override fun getLogger(owner: Any): ComponentLogger {
-        return ComponentLogger.logger(getPluginContainerFromOwner(owner).description.id)
+        ensureOwnerIsPluginContainer(owner)
+        return ComponentLogger.logger(owner.description.id)
     }
 
     override fun getDataPath(owner: Any): Path {
-        return PLUGIN_PATH.resolve(getPluginContainerFromOwner(owner).description.id)
+        ensureOwnerIsPluginContainer(owner)
+        return PLUGIN_PATH.resolve(owner.description.id)
     }
 
-    private fun getPluginContainerFromOwner(owner: Any) =
-        velocityMain.server.pluginManager.ensurePluginContainer(owner)
+    @OptIn(ExperimentalContracts::class)
+    private fun ensureOwnerIsPluginContainer(owner: Any): PluginContainer {
+        contract {
+            returns() implies (owner is PluginContainer)
+        }
 
-    private fun getInstanceFromOwner(owner: Any): Any {
-        return getPluginContainerFromOwner(owner).instance.getOrNull()
-            ?: error("Failed to get instance from owner: $owner")
+        return owner as? PluginContainer ?: error("Owner must be a PluginContainer")
     }
 }


### PR DESCRIPTION
Replace getInstanceFromOwner and getPluginContainerFromOwner helper methods with ensureOwnerIsPluginContainer using Kotlin contracts for type-safe owner validation.

- Add ensureOwnerIsPluginContainer with contract for compile-time type safety
- Use owner directly after validation instead of fetching instance
- Remove optional instance retrieval in favor of direct PluginContainer usage
- Bump version to 1.21.11-2.59.3