### PR TITLE
Add InternalAPIMarker annotation for internal API boundaries

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.59.4
+version=1.21.11-2.60.0
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-shared/surf-api-shared-public/api/surf-api-shared-public.api
+++ b/surf-api-shared/surf-api-shared-public/api/surf-api-shared-public.api
@@ -4,6 +4,9 @@ public final class dev/slne/surf/surfapi/shared/api/annotation/AnnotationUtils {
 	public final fun findAnnotation (Ljava/lang/Class;Ljava/lang/Class;)Ljava/lang/annotation/Annotation;
 }
 
+public abstract interface annotation class dev/slne/surf/surfapi/shared/api/annotation/InternalAPIMarker : java/lang/annotation/Annotation {
+}
+
 public abstract interface class dev/slne/surf/surfapi/shared/api/component/Component {
 	public fun disable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public fun enable (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/surf-api-shared/surf-api-shared-public/src/main/kotlin/dev/slne/surf/surfapi/shared/api/annotation/InternalAPIMarker.kt
+++ b/surf-api-shared/surf-api-shared-public/src/main/kotlin/dev/slne/surf/surfapi/shared/api/annotation/InternalAPIMarker.kt
@@ -1,0 +1,22 @@
+package dev.slne.surf.surfapi.shared.api.annotation
+
+/**
+ * Marker annotation that designates an annotation class as an Internal API marker.
+ *
+ * Annotation classes annotated with [InternalAPIMarker] are recognized by the IntelliJ plugin
+ * to identify internal API boundaries. Declarations annotated with such an annotation will be
+ * treated as invisible to consumers in other projects — similar to Kotlin's
+ * [DeprecationLevel.HIDDEN] behavior — rather than producing an opt-in warning or error.
+ *
+ * Example:
+ * ```kotlin
+ * @RequiresOptIn
+ * @InternalAPIMarker
+ * annotation class InternalSurfAPI
+ *
+ * @InternalSurfAPI
+ * fun internalFunction() { ... }
+ * ```
+ */
+@Target(AnnotationTarget.ANNOTATION_CLASS)
+annotation class InternalAPIMarker


### PR DESCRIPTION
This pull request introduces a new marker annotation for internal API boundaries and updates the project version. The main focus is on improving API visibility control for consumers by providing a standardized way to mark internal APIs.

**API Visibility Improvements**

* Added the new `InternalAPIMarker` annotation class in `surf-api-shared/surf-api-shared-public/src/main/kotlin/dev/slne/surf/surfapi/shared/api/annotation/InternalAPIMarker.kt`, including documentation explaining its usage for marking internal API annotations.
* Declared `InternalAPIMarker` as a public abstract interface annotation in the API definition file `surf-api-shared/surf-api-shared-public/api/surf-api-shared-public.api`.

**Version Update**

* Updated the project version in `gradle.properties` from `1.21.11-2.59.4` to `1.21.11-2.60.0`.