### PR TITLE
Update dependencies and bump version to 1.21.11-2.60.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.60.0
+version=1.21.11-2.60.1
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,8 +11,8 @@ kotlinxCoroutines = "1.10.2"
 kotlinx-serialization = "1.10.0"
 
 # Packet Events
-packetevents = "2.11.0"
-packetevents-plugin = "2.11.0"
+packetevents = "2.11.2"
+packetevents-plugin = "2.11.2"
 
 # Command API
 commandapi = "11.1.0"
@@ -21,18 +21,17 @@ commandapi = "11.1.0"
 luckperms = "v5.5.0-bukkit"
 
 # Scoreboard Library
-scoreboard-library = "2.4.4"
-scoreboard-library-implementation = "2.4.4"
-scoreboard-library-modern = "2.5.0"
+scoreboard-library = "2.7.0"
+scoreboard-library-implementation = "2.7.0"
 
 # Adventure
 adventure-api = "4.26.1"
 
 # Velocity
-velocity-api = "3.4.0-SNAPSHOT"
+velocity-api = "3.5.0-SNAPSHOT"
 
 # PAPI
-placeholder-api = "2.11.6"
+placeholder-api = "2.12.2"
 
 # McCoroutine
 mccoroutine = "2.22.0"
@@ -40,7 +39,7 @@ mccoroutine = "2.22.0"
 # Miscellaneous Libraries
 guava = "33.5.0-jre"
 caffeine = "3.2.3"
-caffeine-courotines = "3.0.1"
+caffeine-courotines = "3.0.2"
 gson = "2.13.2"
 commons-lang3 = "3.20.0"
 commons-text = "1.15.0"
@@ -62,15 +61,15 @@ flogger = "0.9"
 aide-reflection = "1.3"
 auto-service = "1.1.1"
 auto-service-ksp = "1.2.0"
-ktor = "3.4.0"
+ktor = "3.4.1"
 glm = "0.9.9.1-15"
-ksp-version = "2.3.5"
-reactor-netty = "1.3.2"
-bytebuddy = "1.18.4"
+ksp-version = "2.3.6"
+reactor-netty = "1.3.3"
+bytebuddy = "1.18.7"
 
 # Plugin versions
 maven-repo-auth = "3.0.4"
-shadow-gradle-plugin = "9.3.1"
+shadow-gradle-plugin = "9.3.2"
 run-paper-gradle-plugin = "3.0.2"
 dokka = "2.1.0"
 
@@ -108,7 +107,6 @@ commandapi-velocity-kotlin = { module = "dev.jorel:commandapi-kotlin-velocity", 
 # Scoreboard Library
 scoreboard-library-api = { module = "net.megavex:scoreboard-library-api", version.ref = "scoreboard-library" }
 scoreboard-library-implementation = { module = "net.megavex:scoreboard-library-implementation", version.ref = "scoreboard-library-implementation" }
-scoreboard-library-modern = { module = "net.megavex:scoreboard-library-packetevents", version.ref = "scoreboard-library-modern" }
 
 # Adventure
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventure-api" }

--- a/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
+++ b/surf-api-bukkit/surf-api-bukkit-server/build.gradle.kts
@@ -25,7 +25,6 @@ dependencies {
 
     // -------------------- Paper Libraries -------------------- //
     runtimeOnly(libs.scoreboard.library.implementation)
-    runtimeOnly(libs.scoreboard.library.modern)
     paperLibrary(libs.scoreboard.library.api)
     api(libs.stefvanschie.`if`)
     paperLibrary(libs.guava)


### PR DESCRIPTION
This pull request updates several dependencies to their latest versions and removes an unused scoreboard library module from the build. The main focus is on keeping the project up-to-date with recent library releases and cleaning up unnecessary dependencies.

Dependency updates:

* Updated `packetevents` and `packetevents-plugin` to version 2.11.2.
* Updated `scoreboard-library` and `scoreboard-library-implementation` to version 2.7.0, and removed the `scoreboard-library-modern` variant. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL24-R42) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL111) [[3]](diffhunk://#diff-30859833445b42ecb20661376edfdfaaff8d95a1c2aa1d0cd7ba157b4d923483L28)
* Updated several other libraries: `velocity-api` to 3.5.0-SNAPSHOT, `placeholder-api` to 2.12.2, `caffeine-courotines` to 3.0.2, `ktor` to 3.4.1, `ksp-version` to 2.3.6, `reactor-netty` to 1.3.3, `bytebuddy` to 1.18.7, and `shadow-gradle-plugin` to 9.3.2. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL24-R42) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL65-R72)

Build and versioning changes:

* Bumped project version from `1.21.11-2.60.0` to `1.21.11-2.60.1` in `gradle.properties`.

Dependency cleanup:

* Removed the `scoreboard-library-modern` dependency from both the version catalog and the `surf-api-bukkit-server` build script. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL24-R42) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL111) [[3]](diffhunk://#diff-30859833445b42ecb20661376edfdfaaff8d95a1c2aa1d0cd7ba157b4d923483L28)