### PR TITLE
Enhance PacketLoreListener with improved lore and snapshot management

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.65.0
+version=1.21.11-2.66.0
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
+++ b/surf-api-bukkit/surf-api-bukkit-api/api/surf-api-bukkit-api.api
@@ -2155,8 +2155,10 @@ public abstract interface class dev/slne/surf/surfapi/bukkit/api/nms/listener/pa
 public abstract interface class dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi {
 	public static final field Companion Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi$Companion;
 	public static fun getInstance ()Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi;
-	public abstract fun registerPacketLoreListener (Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandler;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandler;)V
 	public fun registerPacketLoreListener (Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
+	public abstract fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandler;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
 	public abstract fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandler;)V
 	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
 	public abstract fun unregisterPacketLoreListener (Lorg/bukkit/NamespacedKey;)V
@@ -2168,7 +2170,9 @@ public final class dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi$C
 }
 
 public final class dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi$DefaultImpls {
+	public static fun registerPacketLoreListener (Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandler;)V
 	public static fun registerPacketLoreListener (Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
+	public static fun registerPacketLoreListener (Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi;Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
 	public static fun registerPacketLoreListenerGlobal (Ldev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi;Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/surfapi/bukkit/api/packet/lore/SurfBukkitPacketLoreHandlerSimple;)V
 }
 

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi.kt
@@ -10,36 +10,48 @@ import org.bukkit.plugin.Plugin
 /**
  * The SurfBukkitPacketApi interface extends packet handling capabilities for Bukkit environments.
  *
- * It provides methods for registering and unregistering lore listeners, enabling dynamic modification
- * of item stack lore based on custom logic. It also includes global registration methods for listening
- * to all items and utilities for managing these listeners efficiently.
+ * Provides methods for registering and unregistering lore listeners, enabling dynamic modification
+ * of item stack lore based on custom logic. Includes global registration for all items and utilities
+ * for managing these listeners efficiently.
  *
- * This API allows developers to enhance item lore dynamically, providing a flexible system for plugins
- * that need to alter or interact with lore without directly modifying the underlying item stack data.
+ * Prefer the overloads that accept an explicit [Plugin] parameter over the deprecated ones,
+ * as automatic caller-plugin detection via `getCallingPlugin` is unreliable across different
+ * call-site configurations.
  */
 interface SurfBukkitPacketApi {
 
     /**
-     * Registers a listener for modifying the lore of a specific item stack identified by the given key.
+     * Registers a listener for modifying the lore of a specific item stack identified by [identifier].
      *
-     * @param identifier A unique key representing the item to listen for. Must not be null.
-     * @param listener   The listener that modifies the lore of the item stack. Must not be null.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The listener that modifies the lore of the item stack.
      *
-     * Example Usage:
-     * ```
-     * val key = NamespacedKey("myplugin", "custom_item")
-     * surfBukkitPacketApi.registerPacketLoreListener(key, SurfBukkitPacketLoreHandler { lore, _, _ ->
-     *     lore.add(Component.text("Special Lore!"))
-     * })
-     * ```
+     * @deprecated Automatic plugin detection via `getCallingPlugin` is unreliable. Use
+     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfBukkitPacketLoreHandler)] instead
+     * and pass your plugin instance explicitly.
      */
+    @Deprecated(
+        message = "Automatic plugin detection is unreliable. Pass your plugin instance explicitly.",
+        replaceWith = ReplaceWith("registerPacketLoreListener(plugin, identifier, listener)")
+    )
     fun registerPacketLoreListener(
         identifier: NamespacedKey,
         listener: SurfBukkitPacketLoreHandler
     ) {
-        registerPacketLoreListener(getCallingPlugin(), identifier, listener)
+        registerPacketLoreListener(getCallingPlugin(2), identifier, listener)
     }
 
+    /**
+     * Registers a listener for modifying the lore of a specific item stack identified by [identifier].
+     *
+     * This is the preferred overload. The [plugin] reference is used to properly manage the
+     * listener lifecycle — all listeners registered under a plugin are automatically cleaned up
+     * when [unregisterPacketLoreListener(Plugin)] is called.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The listener that modifies the lore of the item stack.
+     */
     fun registerPacketLoreListener(
         plugin: Plugin,
         identifier: NamespacedKey,
@@ -47,20 +59,39 @@ interface SurfBukkitPacketApi {
     )
 
     /**
-     * Registers a simplified packet lore listener for a specific item.
+     * Registers a simplified listener for modifying the lore of a specific item stack identified by [identifier].
      *
-     * @param identifier A unique key representing the item to listen for. Must not be null.
-     * @param listener   The simplified packet lore listener that focuses solely on modifying the lore list.
+     * Delegates to [registerPacketLoreListener(Plugin, NamespacedKey, SurfBukkitPacketLoreHandler)].
      *
-     * This method delegates to the standard [registerPacketLoreListener] implementation.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The simplified lore listener that focuses solely on modifying the lore list.
+     *
+     * @deprecated Automatic plugin detection is unreliable. Use
+     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfBukkitPacketLoreHandlerSimple)] instead
+     * and pass your plugin instance explicitly.
      */
+    @Deprecated(
+        message = "Automatic plugin detection is unreliable. Pass your plugin instance explicitly.",
+        replaceWith = ReplaceWith("registerPacketLoreListener(plugin, identifier, listener)")
+    )
     fun registerPacketLoreListener(
         identifier: NamespacedKey,
         listener: SurfBukkitPacketLoreHandlerSimple
     ) {
-        registerPacketLoreListener(getCallingPlugin(), identifier, listener)
+        registerPacketLoreListener(getCallingPlugin(2), identifier, listener)
     }
 
+    /**
+     * Registers a simplified listener for modifying the lore of a specific item stack identified by [identifier].
+     *
+     * This is the preferred overload. Delegates to
+     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfBukkitPacketLoreHandler)].
+     * The [plugin] reference is used to properly manage the listener lifecycle.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The simplified lore listener that focuses solely on modifying the lore list.
+     */
     fun registerPacketLoreListener(
         plugin: Plugin,
         identifier: NamespacedKey,
@@ -70,17 +101,14 @@ interface SurfBukkitPacketApi {
     }
 
     /**
-     * Registers a packet lore listener globally to handle lore modifications for all items.
+     * Registers a lore listener globally to handle lore modifications for all items.
      *
-     * @param plugin   The plugin registering the listener. Used to manage lifecycle and cleanup.
+     * Unlike the key-based overloads, this listener fires for every item stack regardless of
+     * its identifier. Use this only when you genuinely need to intercept all items, as it has
+     * a broader performance impact.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
      * @param listener The lore listener to handle lore modifications globally.
-     *
-     * Example Usage:
-     * ```
-     * surfBukkitPacketApi.registerPacketLoreListenerGlobal(myPlugin, SurfBukkitPacketLoreHandler { lore, _, _ ->
-     *     lore.add(Component.text("Global Lore Modification"))
-     * })
-     * ```
      */
     fun registerPacketLoreListenerGlobal(
         plugin: Plugin,
@@ -88,12 +116,12 @@ interface SurfBukkitPacketApi {
     )
 
     /**
-     * Registers a simplified packet lore listener globally for all items.
+     * Registers a simplified lore listener globally for all items.
      *
-     * @param plugin   The plugin registering the listener. Used for proper cleanup during plugin shutdown.
+     * Delegates to [registerPacketLoreListenerGlobal(Plugin, SurfBukkitPacketLoreHandler)].
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
      * @param listener The simplified lore listener that focuses solely on the lore list.
-     *
-     * This method delegates to the standard [registerPacketLoreListenerGlobal] implementation.
      */
     fun registerPacketLoreListenerGlobal(
         plugin: Plugin,
@@ -103,26 +131,19 @@ interface SurfBukkitPacketApi {
     }
 
     /**
-     * Unregisters a previously registered packet lore listener identified by the given key.
+     * Unregisters the packet lore listener associated with the given [identifier].
      *
      * @param identifier The key identifying the listener to unregister.
-     *
-     * Example Usage:
-     * ```
-     * surfBukkitPacketApi.unregisterPacketLoreListener(NamespacedKey("myplugin", "custom_item"))
-     * ```
      */
     fun unregisterPacketLoreListener(identifier: NamespacedKey)
 
     /**
-     * Unregisters all packet lore listeners associated with the given plugin.
+     * Unregisters all packet lore listeners associated with the given [plugin].
+     *
+     * Call this during plugin shutdown to ensure all listeners registered under this plugin
+     * are properly cleaned up.
      *
      * @param plugin The plugin whose listeners should be unregistered.
-     *
-     * Example Usage:
-     * ```
-     * surfBukkitPacketApi.unregisterPacketLoreListener(myPlugin)
-     * ```
      */
     fun unregisterPacketLoreListener(plugin: Plugin)
 
@@ -131,5 +152,3 @@ interface SurfBukkitPacketApi {
         val instance = requiredService<SurfBukkitPacketApi>()
     }
 }
-
-val surfBukkitPacketApi get() = SurfBukkitPacketApi.instance

--- a/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi.kt
+++ b/surf-api-bukkit/surf-api-bukkit-api/src/main/kotlin/dev/slne/surf/surfapi/bukkit/api/packet/SurfBukkitPacketApi.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.surfapi.bukkit.api.packet
 
 import dev.slne.surf.surfapi.bukkit.api.packet.lore.SurfBukkitPacketLoreHandler
 import dev.slne.surf.surfapi.bukkit.api.packet.lore.SurfBukkitPacketLoreHandlerSimple
+import dev.slne.surf.surfapi.bukkit.api.util.getCallingPlugin
 import dev.slne.surf.surfapi.core.api.util.requiredService
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
@@ -35,6 +36,14 @@ interface SurfBukkitPacketApi {
     fun registerPacketLoreListener(
         identifier: NamespacedKey,
         listener: SurfBukkitPacketLoreHandler
+    ) {
+        registerPacketLoreListener(getCallingPlugin(), identifier, listener)
+    }
+
+    fun registerPacketLoreListener(
+        plugin: Plugin,
+        identifier: NamespacedKey,
+        listener: SurfBukkitPacketLoreHandler
     )
 
     /**
@@ -49,7 +58,15 @@ interface SurfBukkitPacketApi {
         identifier: NamespacedKey,
         listener: SurfBukkitPacketLoreHandlerSimple
     ) {
-        registerPacketLoreListener(identifier, listener as SurfBukkitPacketLoreHandler)
+        registerPacketLoreListener(getCallingPlugin(), identifier, listener)
+    }
+
+    fun registerPacketLoreListener(
+        plugin: Plugin,
+        identifier: NamespacedKey,
+        listener: SurfBukkitPacketLoreHandlerSimple
+    ) {
+        registerPacketLoreListener(plugin, identifier, listener as SurfBukkitPacketLoreHandler)
     }
 
     /**

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/packet/SurfBukkitPacketApiImpl.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/packet/SurfBukkitPacketApiImpl.kt
@@ -15,10 +15,11 @@ class SurfBukkitPacketApiImpl : SurfBukkitPacketApi {
     }
 
     override fun registerPacketLoreListener(
+        plugin: Plugin,
         identifier: NamespacedKey,
         listener: SurfBukkitPacketLoreHandler
     ) {
-        PacketLoreListener.register(identifier, listener)
+        PacketLoreListener.register(plugin, identifier, listener)
     }
 
     override fun registerPacketLoreListenerGlobal(

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/PacketApiLoader.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/PacketApiLoader.kt
@@ -1,11 +1,14 @@
 package dev.slne.surf.surfapi.bukkit.server.packet
 
 import com.github.retrooper.packetevents.PacketEvents
+import dev.slne.surf.surfapi.bukkit.api.event.register
+import dev.slne.surf.surfapi.bukkit.api.event.unregister
 import dev.slne.surf.surfapi.bukkit.api.nms.NmsUseWithCaution
 import dev.slne.surf.surfapi.bukkit.api.packet.listener.packetListenerApi
 import dev.slne.surf.surfapi.bukkit.server.impl.glow.GlowingPacketListener
 import dev.slne.surf.surfapi.bukkit.server.packet.listener.PlayerChannelInjector
 import dev.slne.surf.surfapi.bukkit.server.packet.lore.PacketLoreListener
+import dev.slne.surf.surfapi.bukkit.server.packet.lore.PluginDisablePacketLoreListener
 import dev.slne.surf.surfapi.bukkit.server.plugin
 import dev.slne.surf.surfapi.core.api.extensions.packetEvents
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder
@@ -23,12 +26,14 @@ object PacketApiLoader {
         packetListenerApi.registerListeners(GlowingPacketListener)
 
         PlayerChannelInjector.register()
+        PluginDisablePacketLoreListener.register()
     }
 
     @OptIn(NmsUseWithCaution::class)
     fun onDisable() {
         packetEvents.terminate()
         packetListenerApi.unregisterListeners(PacketLoreListener)
+        PluginDisablePacketLoreListener.unregister()
     }
 
     private fun setupPacketEvents() {

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
@@ -8,8 +8,9 @@ import dev.slne.surf.surfapi.bukkit.api.packet.lore.SurfBukkitPacketLoreHandler
 import dev.slne.surf.surfapi.bukkit.api.util.key
 import dev.slne.surf.surfapi.bukkit.server.nms.toBukkit
 import dev.slne.surf.surfapi.bukkit.server.nms.toNms
-import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
+import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
+import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
 import net.minecraft.network.protocol.game.*
@@ -18,8 +19,6 @@ import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.item.component.ItemLore
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
-import java.util.concurrent.ConcurrentHashMap
-import net.kyori.adventure.text.Component as AdventureComponent
 import net.minecraft.network.chat.Component as MinecraftComponent
 
 /**
@@ -28,23 +27,22 @@ import net.minecraft.network.chat.Component as MinecraftComponent
  */
 @OptIn(NmsUseWithCaution::class)
 object PacketLoreListener : PacketListener {
-    private val loreHandlers = ConcurrentHashMap<NamespacedKey, SurfBukkitPacketLoreHandler>()
-    private val loreHandlersGlobal = ConcurrentHashMap<Plugin, MutableSet<SurfBukkitPacketLoreHandler>>()
+    private val globalHandlersByPlugin =
+        Object2ObjectLinkedOpenHashMap<Plugin, ObjectLinkedOpenHashSet<SurfBukkitPacketLoreHandler>>()
+
+    private val keyedHandlersByPlugin =
+        Object2ObjectLinkedOpenHashMap<Plugin, Object2ObjectLinkedOpenHashMap<NamespacedKey, SurfBukkitPacketLoreHandler>>()
 
     @Volatile
-    private var loreHandlerSnapshot: Array<Map.Entry<NamespacedKey, SurfBukkitPacketLoreHandler>> = emptyArray()
+    private var keyedHandlersSnapshot: Map<NamespacedKey, SurfBukkitPacketLoreHandler> = emptyMap()
 
     @Volatile
-    private var loreHandlerGlobalSnapshot: Array<Map.Entry<Plugin, MutableSet<SurfBukkitPacketLoreHandler>>> =
-        emptyArray()
+    private var globalHandlersSnapshot: Array<SurfBukkitPacketLoreHandler> = emptyArray()
 
     private val ORIGINAL_LORE_KEY = key("original_lore")
     private val ORIGINAL_LORE_KEY_STRING = ORIGINAL_LORE_KEY.asString()
 
-    private val ITALIC_DECORATION = TextDecoration.ITALIC
-    private val ITALIC_STATE_FALSE = TextDecoration.State.FALSE
-
-    private fun hasAnyHandlers(): Boolean = loreHandlerSnapshot.isNotEmpty() || loreHandlerGlobalSnapshot.isNotEmpty()
+    private fun hasAnyHandlers(): Boolean = keyedHandlersSnapshot.isNotEmpty() || globalHandlersSnapshot.isNotEmpty()
 
     @ServerboundListener
     fun onPacketReceive(event: ServerboundSetCreativeModeSlotPacket) {
@@ -55,109 +53,164 @@ object PacketLoreListener : PacketListener {
     fun onWindowItem(event: ClientboundContainerSetContentPacket): ClientboundContainerSetContentPacket {
         if (!hasAnyHandlers()) return event
 
-        val items = event.items
-        val updatedItems = ObjectArrayList<ItemStack>(items.size)
-        for (i in items.indices) {
-            updatedItems.add(makeUpdatedItemStack(items[i].copy()))
+        val sourceItems = event.items
+        val updatedItems = ObjectArrayList<ItemStack>(sourceItems.size)
+
+        var changed = false
+
+        for (i in sourceItems.indices) {
+            val original = sourceItems[i]
+            val updated = makeUpdatedItemStack(original)
+
+            if (updated !== original) {
+                changed = true
+            }
+
+            updatedItems.add(updated)
+        }
+
+        val originalCarried = event.carriedItem()
+        val updatedCarried = makeUpdatedItemStack(originalCarried)
+
+        if (updatedCarried !== originalCarried) {
+            changed = true
+        }
+
+        if (!changed) {
+            return event
         }
 
         return ClientboundContainerSetContentPacket(
             event.containerId(),
             event.stateId(),
-            items,
-            makeUpdatedItemStack(event.carriedItem().copy())
+            updatedItems,
+            updatedCarried
         )
     }
 
     @ClientboundListener
     fun onSetSlotPacket(event: ClientboundContainerSetSlotPacket): ClientboundContainerSetSlotPacket {
-        if (!hasAnyHandlers()) return event
+        val original = event.item
+        val updated = makeUpdatedItemStack(original)
+
+        if (updated === original) {
+            return event
+        }
 
         return ClientboundContainerSetSlotPacket(
             event.containerId,
             event.stateId,
             event.slot,
-            makeUpdatedItemStack(event.item.copy())
+            updated
         )
     }
 
     @ClientboundListener
     fun onSetPlayerInventoryPacket(event: ClientboundSetPlayerInventoryPacket): ClientboundSetPlayerInventoryPacket {
-        if (!hasAnyHandlers()) return event
+        val original = event.contents
+        val updated = makeUpdatedItemStack(original)
+
+        if (updated === original) {
+            return event
+        }
 
         return ClientboundSetPlayerInventoryPacket(
             event.slot(),
-            makeUpdatedItemStack(event.contents.copy())
+            updated
         )
     }
 
     @ClientboundListener
     fun onSetCursorItemPacket(event: ClientboundSetCursorItemPacket): ClientboundSetCursorItemPacket {
-        if (!hasAnyHandlers()) return event
+        val original = event.contents
+        val updated = makeUpdatedItemStack(original)
 
-        return ClientboundSetCursorItemPacket(makeUpdatedItemStack(event.contents.copy()))
-    }
-
-    private fun makeUpdatedItemStack(
-        item: ItemStack,
-    ): ItemStack {
-        if (item.isEmpty) return item
-
-        // One volatile read
-        val handlerEntries = loreHandlerSnapshot
-        val globalEntries = loreHandlerGlobalSnapshot
-
-        val nmsLore = item.getOrDefault(DataComponents.LORE, ItemLore.EMPTY)
-        val lines = nmsLore.lines
-
-        val mutableLore = mutableObjectListOf<AdventureComponent>(lines.size)
-        for (i in lines.indices) {
-            mutableLore.add(lines[i].toBukkit())
+        if (updated === original) {
+            return event
         }
 
+        return ClientboundSetCursorItemPacket(updated)
+    }
+
+    /**
+     * Returns the original item if:
+     * - item is empty
+     * - no handlers exist
+     * - no keyed handler matches and no global handler exists
+     * - handlers run but lore result is identical
+     *
+     * Only copies the stack if at least one handler will actually run.
+     */
+    private fun makeUpdatedItemStack(
+        original: ItemStack,
+    ): ItemStack {
+        if (original.isEmpty) return original
+
+        // One volatile read
+        val keyedSnapshot = keyedHandlersSnapshot
+        val globalSnapshot = globalHandlersSnapshot
+
+        if (keyedSnapshot.isEmpty() && globalSnapshot.isEmpty()) {
+            return original
+        }
+
+        /*
+         * We need Bukkit PDC for the current handler API.
+         * But we only use the original mirror to cheaply determine
+         * whether any keyed handlers actually match.
+         */
+        val originalBukkitStack = original.asBukkitMirror()
+        val originalPdc = originalBukkitStack.persistentDataContainer
+
+        val matchingKeyedHandlers = resolveMatchingKeyedHandlers(
+            originalPdc.keys,
+            keyedSnapshot
+        )
+
+        if (matchingKeyedHandlers.isEmpty() && globalSnapshot.isEmpty()) {
+            return original
+        }
+
+        /*
+        * From here on, we know that at least one handler will run.
+        * Only now create a copy.
+        */
+        val item = original.copy()
         val bukkitStack = item.asBukkitMirror()
         val pdc = bukkitStack.persistentDataContainer
 
-        var anyHandlerRan = false
-        if (handlerEntries.isNotEmpty()) {
-            for ((key, handler) in handlerEntries) {
-                if (pdc.has(key)) {
-                    handler.handleLore(mutableLore, pdc, bukkitStack)
-                    anyHandlerRan = true
-                }
-            }
+        val originalLore = item.getOrDefault(DataComponents.LORE, ItemLore.EMPTY)
+        val originalLines = originalLore.lines
+
+        val mutableLore = originalLines.mapTo(
+            ObjectArrayList(originalLines.size)
+        ) { it.toBukkit() }
+
+        for (i in matchingKeyedHandlers.indices) {
+            matchingKeyedHandlers[i].handleLore(mutableLore, pdc, bukkitStack)
         }
 
-        if (globalEntries.isNotEmpty()) {
-            for ((plugin, handlers) in globalEntries) {
-                if (plugin.isEnabled) {
-                    for (handler in handlers) {
-                        handler.handleLore(mutableLore, pdc, bukkitStack)
-                        anyHandlerRan = true
-                    }
-                }
-            }
+        for (i in globalSnapshot.indices) {
+            globalSnapshot[i].handleLore(mutableLore, pdc, bukkitStack)
         }
-
-        if (!anyHandlerRan) return item
 
         val updatedLines = ObjectArrayList<MinecraftComponent>(mutableLore.size)
         for (i in mutableLore.indices) {
-            val component = mutableLore[i]
-            updatedLines.add(
-                component.decorationIfAbsent(ITALIC_DECORATION, ITALIC_STATE_FALSE).toNms()
-            )
+            val line = mutableLore[i].decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE)
+            updatedLines.add(line.toNms())
         }
 
-        val updatedNmsLore = ItemLore(updatedLines)
+        val updatedLore = ItemLore(updatedLines)
 
-        if (updatedNmsLore == nmsLore) {
-            return item
+        if (updatedLore == originalLore) {
+            return original
         }
 
-        item.set(DataComponents.LORE, updatedNmsLore)
+        item.set(DataComponents.LORE, updatedLore)
         CustomData.update(DataComponents.CUSTOM_DATA, item) { tag ->
-            tag.store(ORIGINAL_LORE_KEY_STRING, ItemLore.CODEC, nmsLore)
+            if (!tag.contains(ORIGINAL_LORE_KEY_STRING)) {
+                tag.store(ORIGINAL_LORE_KEY_STRING, ItemLore.CODEC, originalLore)
+            }
         }
 
         return item
@@ -166,6 +219,15 @@ object PacketLoreListener : PacketListener {
     private fun makeCleanItemStack(
         stack: ItemStack,
     ): ItemStack {
+        if (stack.isEmpty) {
+            return stack
+        }
+
+        val customData = stack.get(DataComponents.CUSTOM_DATA) ?: return stack
+        if (!customData.contains(ORIGINAL_LORE_KEY_STRING)) {
+            return stack
+        }
+
         CustomData.update(DataComponents.CUSTOM_DATA, stack) { tag ->
             val originalLore = tag.read(ORIGINAL_LORE_KEY_STRING, ItemLore.CODEC)
             originalLore.ifPresent { lore ->
@@ -177,28 +239,112 @@ object PacketLoreListener : PacketListener {
         return stack
     }
 
-    private fun rebuildSnapshots() {
-        loreHandlerSnapshot = loreHandlers.entries.toTypedArray()
-        loreHandlerGlobalSnapshot = loreHandlersGlobal.entries.toTypedArray()
+    private fun resolveMatchingKeyedHandlers(
+        itemKeys: Set<NamespacedKey>,
+        keyedSnapshot: Map<NamespacedKey, SurfBukkitPacketLoreHandler>,
+    ): List<SurfBukkitPacketLoreHandler> {
+        if (itemKeys.isEmpty() || keyedSnapshot.isEmpty()) {
+            return emptyList()
+        }
+
+        var result: ObjectArrayList<SurfBukkitPacketLoreHandler>? = null
+        for (key in itemKeys) {
+            val handler = keyedSnapshot[key] ?: continue
+
+            if (result == null) {
+                result = ObjectArrayList(2)
+            }
+
+            result.add(handler)
+        }
+
+        return result ?: emptyList()
     }
 
-    fun register(identifier: NamespacedKey, listener: SurfBukkitPacketLoreHandler) {
-        loreHandlers[identifier] = listener
-        rebuildSnapshots()
+    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfBukkitPacketLoreHandler) {
+        synchronized(this) {
+            check(!keyedHandlersSnapshot.containsKey(identifier)) {
+                "A PacketLore handler for $identifier is already registered!"
+            }
+
+            val handlers = keyedHandlersByPlugin.computeIfAbsent(plugin) { Object2ObjectLinkedOpenHashMap() }
+
+            val previous = handlers.putIfAbsent(identifier, listener)
+            check(previous == null) {
+                "A PacketLore handler for $identifier is already registered for plugin ${plugin.name}!"
+            }
+
+            val newSnapshot = Object2ObjectLinkedOpenHashMap(keyedHandlersSnapshot)
+            newSnapshot[identifier] = listener
+            keyedHandlersSnapshot = newSnapshot
+        }
     }
 
     fun register(plugin: Plugin, listener: SurfBukkitPacketLoreHandler) {
-        loreHandlersGlobal.computeIfAbsent(plugin) { ConcurrentHashMap.newKeySet() }.add(listener)
-        rebuildSnapshots()
+        synchronized(this) {
+            val handlers = globalHandlersByPlugin.computeIfAbsent(plugin) { ObjectLinkedOpenHashSet() }
+            if (handlers.add(listener)) {
+                rebuildGlobalHandlersSnapshot()
+            } else {
+                error("A PacketLore handler identical to the provided one (${listener.javaClass.name}) is already registered for plugin ${plugin.name}!")
+            }
+        }
     }
 
     fun unregister(identifier: NamespacedKey) {
-        loreHandlers.remove(identifier)
-        rebuildSnapshots()
+        synchronized(this) {
+            if (!keyedHandlersSnapshot.containsKey(identifier)) {
+                return
+            }
+
+            var emptyPlugin: Plugin? = null
+
+            for ((plugin, handlers) in keyedHandlersByPlugin) {
+                if (handlers.remove(identifier) != null) {
+                    if (handlers.isEmpty()) {
+                        emptyPlugin = plugin
+                    }
+                    break
+                }
+            }
+
+            if (emptyPlugin != null) {
+                keyedHandlersByPlugin.remove(emptyPlugin)
+            }
+
+            val newSnapshot = Object2ObjectLinkedOpenHashMap(keyedHandlersSnapshot)
+            newSnapshot.remove(identifier)
+            keyedHandlersSnapshot = newSnapshot
+        }
     }
 
     fun unregister(plugin: Plugin) {
-        loreHandlersGlobal.remove(plugin)
-        rebuildSnapshots()
+        synchronized(this) {
+            val removedGlobal = globalHandlersByPlugin.remove(plugin) != null
+            if (removedGlobal) {
+                rebuildGlobalHandlersSnapshot()
+            }
+
+            val removedKeyed = keyedHandlersByPlugin.remove(plugin)
+            if (removedKeyed != null) {
+                val newSnapshot = Object2ObjectLinkedOpenHashMap(keyedHandlersSnapshot)
+                for (identifier in removedKeyed.keys) {
+                    newSnapshot.remove(identifier)
+                }
+                keyedHandlersSnapshot = newSnapshot
+            }
+        }
+    }
+
+    private fun rebuildGlobalHandlersSnapshot() {
+        val snapshot = ObjectArrayList<SurfBukkitPacketLoreHandler>()
+
+        globalHandlersByPlugin.object2ObjectEntrySet().fastForEach { (plugin, handlers) ->
+            if (plugin.isEnabled) {
+                snapshot.addAll(handlers)
+            }
+        }
+
+        globalHandlersSnapshot = snapshot.toTypedArray()
     }
 }

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
@@ -11,6 +11,7 @@ import dev.slne.surf.surfapi.bukkit.server.nms.toNms
 import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap
 import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet
+import it.unimi.dsi.fastutil.objects.ObjectLists
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
 import net.minecraft.network.protocol.game.*
@@ -155,17 +156,20 @@ object PacketLoreListener : PacketListener {
         }
 
         /*
-         * We need Bukkit PDC for the current handler API.
-         * But we only use the original mirror to cheaply determine
-         * whether any keyed handlers actually match.
+         * We need Bukkit PDC for the current handler API, but only when there
+         * are keyed handlers to consider. The original mirror is used to cheaply
+         * determine whether any keyed handlers actually match.
          */
-        val originalBukkitStack = original.asBukkitMirror()
-        val originalPdc = originalBukkitStack.persistentDataContainer
-
-        val matchingKeyedHandlers = resolveMatchingKeyedHandlers(
-            originalPdc.keys,
-            keyedSnapshot
-        )
+        val matchingKeyedHandlers = if (keyedSnapshot.isNotEmpty()) {
+            val originalBukkitStack = original.asBukkitMirror()
+            val originalPdc = originalBukkitStack.persistentDataContainer
+            resolveMatchingKeyedHandlers(
+                originalPdc.keys,
+                keyedSnapshot
+            )
+        } else {
+            ObjectLists.emptyList()
+        }
 
         if (matchingKeyedHandlers.isEmpty() && globalSnapshot.isEmpty()) {
             return original

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
@@ -9,6 +9,7 @@ import dev.slne.surf.surfapi.bukkit.api.util.key
 import dev.slne.surf.surfapi.bukkit.server.nms.toBukkit
 import dev.slne.surf.surfapi.bukkit.server.nms.toNms
 import dev.slne.surf.surfapi.core.api.util.mutableObjectListOf
+import it.unimi.dsi.fastutil.objects.ObjectArrayList
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
 import net.minecraft.network.protocol.game.*
@@ -18,6 +19,8 @@ import net.minecraft.world.item.component.ItemLore
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
 import java.util.concurrent.ConcurrentHashMap
+import net.kyori.adventure.text.Component as AdventureComponent
+import net.minecraft.network.chat.Component as MinecraftComponent
 
 /**
  * PacketLoreListener is a class that implements PacketListenerAbstract and is responsible for
@@ -28,7 +31,20 @@ object PacketLoreListener : PacketListener {
     private val loreHandlers = ConcurrentHashMap<NamespacedKey, SurfBukkitPacketLoreHandler>()
     private val loreHandlersGlobal = ConcurrentHashMap<Plugin, MutableSet<SurfBukkitPacketLoreHandler>>()
 
+    @Volatile
+    private var loreHandlerSnapshot: Array<Map.Entry<NamespacedKey, SurfBukkitPacketLoreHandler>> = emptyArray()
+
+    @Volatile
+    private var loreHandlerGlobalSnapshot: Array<Map.Entry<Plugin, MutableSet<SurfBukkitPacketLoreHandler>>> =
+        emptyArray()
+
     private val ORIGINAL_LORE_KEY = key("original_lore")
+    private val ORIGINAL_LORE_KEY_STRING = ORIGINAL_LORE_KEY.asString()
+
+    private val ITALIC_DECORATION = TextDecoration.ITALIC
+    private val ITALIC_STATE_FALSE = TextDecoration.State.FALSE
+
+    private fun hasAnyHandlers(): Boolean = loreHandlerSnapshot.isNotEmpty() || loreHandlerGlobalSnapshot.isNotEmpty()
 
     @ServerboundListener
     fun onPacketReceive(event: ServerboundSetCreativeModeSlotPacket) {
@@ -37,16 +53,26 @@ object PacketLoreListener : PacketListener {
 
     @ClientboundListener
     fun onWindowItem(event: ClientboundContainerSetContentPacket): ClientboundContainerSetContentPacket {
+        if (!hasAnyHandlers()) return event
+
+        val items = event.items
+        val updatedItems = ObjectArrayList<ItemStack>(items.size)
+        for (i in items.indices) {
+            updatedItems.add(makeUpdatedItemStack(items[i].copy()))
+        }
+
         return ClientboundContainerSetContentPacket(
             event.containerId(),
             event.stateId(),
-            event.items.map { makeUpdatedItemStack(it.copy()) },
+            items,
             makeUpdatedItemStack(event.carriedItem().copy())
         )
     }
 
     @ClientboundListener
     fun onSetSlotPacket(event: ClientboundContainerSetSlotPacket): ClientboundContainerSetSlotPacket {
+        if (!hasAnyHandlers()) return event
+
         return ClientboundContainerSetSlotPacket(
             event.containerId,
             event.stateId,
@@ -57,6 +83,8 @@ object PacketLoreListener : PacketListener {
 
     @ClientboundListener
     fun onSetPlayerInventoryPacket(event: ClientboundSetPlayerInventoryPacket): ClientboundSetPlayerInventoryPacket {
+        if (!hasAnyHandlers()) return event
+
         return ClientboundSetPlayerInventoryPacket(
             event.slot(),
             makeUpdatedItemStack(event.contents.copy())
@@ -65,6 +93,8 @@ object PacketLoreListener : PacketListener {
 
     @ClientboundListener
     fun onSetCursorItemPacket(event: ClientboundSetCursorItemPacket): ClientboundSetCursorItemPacket {
+        if (!hasAnyHandlers()) return event
+
         return ClientboundSetCursorItemPacket(makeUpdatedItemStack(event.contents.copy()))
     }
 
@@ -72,32 +102,54 @@ object PacketLoreListener : PacketListener {
         item: ItemStack,
     ): ItemStack {
         if (item.isEmpty) return item
-        if (loreHandlers.isEmpty() && loreHandlersGlobal.isEmpty()) return item
+
+        // One volatile read
+        val handlerEntries = loreHandlerSnapshot
+        val globalEntries = loreHandlerGlobalSnapshot
+
+        val nmsLore = item.getOrDefault(DataComponents.LORE, ItemLore.EMPTY)
+        val lines = nmsLore.lines
+
+        val mutableLore = mutableObjectListOf<AdventureComponent>(lines.size)
+        for (i in lines.indices) {
+            mutableLore.add(lines[i].toBukkit())
+        }
 
         val bukkitStack = item.asBukkitMirror()
         val pdc = bukkitStack.persistentDataContainer
-        val nmsLore = item.getOrDefault(DataComponents.LORE, ItemLore.EMPTY)
-        val lines = nmsLore.lines
-        val mutableLore = lines.mapTo(mutableObjectListOf(lines.size)) { it.toBukkit() }
 
-        loreHandlers.forEach { (identifier, handler) ->
-            if (pdc.has(identifier)) {
-                handler.handleLore(mutableLore, pdc, bukkitStack)
+        var anyHandlerRan = false
+        if (handlerEntries.isNotEmpty()) {
+            for ((key, handler) in handlerEntries) {
+                if (pdc.has(key)) {
+                    handler.handleLore(mutableLore, pdc, bukkitStack)
+                    anyHandlerRan = true
+                }
             }
         }
 
-        loreHandlersGlobal.forEach { (plugin, handlers) ->
-            if (plugin.isEnabled) {
-                handlers.forEach { it.handleLore(mutableLore, pdc, bukkitStack) }
+        if (globalEntries.isNotEmpty()) {
+            for ((plugin, handlers) in globalEntries) {
+                if (plugin.isEnabled) {
+                    for (handler in handlers) {
+                        handler.handleLore(mutableLore, pdc, bukkitStack)
+                        anyHandlerRan = true
+                    }
+                }
             }
         }
 
-        val updatedNmsLore = ItemLore(
-            mutableLore.asSequence()
-                .map { it.decorationIfAbsent(TextDecoration.ITALIC, TextDecoration.State.FALSE) }
-                .map { it.toNms() }
-                .toList()
-        )
+        if (!anyHandlerRan) return item
+
+        val updatedLines = ObjectArrayList<MinecraftComponent>(mutableLore.size)
+        for (i in mutableLore.indices) {
+            val component = mutableLore[i]
+            updatedLines.add(
+                component.decorationIfAbsent(ITALIC_DECORATION, ITALIC_STATE_FALSE).toNms()
+            )
+        }
+
+        val updatedNmsLore = ItemLore(updatedLines)
 
         if (updatedNmsLore == nmsLore) {
             return item
@@ -105,7 +157,7 @@ object PacketLoreListener : PacketListener {
 
         item.set(DataComponents.LORE, updatedNmsLore)
         CustomData.update(DataComponents.CUSTOM_DATA, item) { tag ->
-            tag.store(ORIGINAL_LORE_KEY.asString(), ItemLore.CODEC, nmsLore)
+            tag.store(ORIGINAL_LORE_KEY_STRING, ItemLore.CODEC, nmsLore)
         }
 
         return item
@@ -115,29 +167,38 @@ object PacketLoreListener : PacketListener {
         stack: ItemStack,
     ): ItemStack {
         CustomData.update(DataComponents.CUSTOM_DATA, stack) { tag ->
-            val originalLore = tag.read(ORIGINAL_LORE_KEY.asString(), ItemLore.CODEC)
+            val originalLore = tag.read(ORIGINAL_LORE_KEY_STRING, ItemLore.CODEC)
             originalLore.ifPresent { lore ->
                 stack.set(DataComponents.LORE, lore)
-                tag.remove(ORIGINAL_LORE_KEY.asString())
+                tag.remove(ORIGINAL_LORE_KEY_STRING)
             }
         }
 
         return stack
     }
 
+    private fun rebuildSnapshots() {
+        loreHandlerSnapshot = loreHandlers.entries.toTypedArray()
+        loreHandlerGlobalSnapshot = loreHandlersGlobal.entries.toTypedArray()
+    }
+
     fun register(identifier: NamespacedKey, listener: SurfBukkitPacketLoreHandler) {
         loreHandlers[identifier] = listener
+        rebuildSnapshots()
     }
 
     fun register(plugin: Plugin, listener: SurfBukkitPacketLoreHandler) {
         loreHandlersGlobal.computeIfAbsent(plugin) { ConcurrentHashMap.newKeySet() }.add(listener)
+        rebuildSnapshots()
     }
 
     fun unregister(identifier: NamespacedKey) {
         loreHandlers.remove(identifier)
+        rebuildSnapshots()
     }
 
     fun unregister(plugin: Plugin) {
         loreHandlersGlobal.remove(plugin)
+        rebuildSnapshots()
     }
 }

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PluginDisablePacketLoreListener.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PluginDisablePacketLoreListener.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.surfapi.bukkit.server.packet.lore
+
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import org.bukkit.event.server.PluginDisableEvent
+
+object PluginDisablePacketLoreListener : Listener {
+
+    @EventHandler
+    fun onPluginDisable(event: PluginDisableEvent) {
+        PacketLoreListener.unregister(event.plugin)
+    }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the lore packet handler system in the Bukkit API. The core changes revolve around making packet lore handler registration and unregistration plugin-aware, improving performance and thread safety, and ensuring proper cleanup when plugins are disabled. The code now uses more efficient data structures, supports per-plugin handler management, and avoids unnecessary work when no handlers are present.

**Lore Handler Registration and Management Improvements:**

* Refactored `PacketLoreListener` to manage lore handlers per-plugin using fastutil collections, with thread-safe snapshots for keyed and global handlers. Registration and unregistration now require specifying the plugin, preventing handler collisions and enabling better lifecycle management. [[1]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fL20-R45) [[2]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fR222-R348)
* Updated the `SurfBukkitPacketApi` interface and its implementation to add overloads for registering lore handlers with an explicit `Plugin` parameter, and defaulting to the calling plugin when not specified. [[1]](diffhunk://#diff-1988dd2fcd88ad00caa30f8bc67da90d4b96d3c2a3a2dfec29b0ec5d80151deaR39-R46) [[2]](diffhunk://#diff-1988dd2fcd88ad00caa30f8bc67da90d4b96d3c2a3a2dfec29b0ec5d80151deaL52-R69) [[3]](diffhunk://#diff-c14aeb6e8383ef3252e6bdd26136a08e2f455da490ab50ae6af8217ecf3f9ebdR18-R22)
* Added a new `PluginDisablePacketLoreListener` which listens for `PluginDisableEvent` and automatically unregisters all lore handlers associated with the disabled plugin, ensuring clean resource management. [[1]](diffhunk://#diff-e1eaa0afddbcb7890fca4b83c93650693728256671e5855c7b90710925047e4eR1-R13) [[2]](diffhunk://#diff-5c854fc015902121b16c77102806b42027bed61922a911bfd0d0c9f95289e612R29-R36)

**Performance and Correctness Enhancements:**

* Optimized lore modification logic to avoid copying or modifying item stacks unless at least one handler will actually run and produce a change, reducing unnecessary allocations and improving efficiency.
* Ensured that lore handlers are only invoked when relevant, and that item stacks are only updated if the lore actually changes, preserving original lore using a unique key for restoration when needed. [[1]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fR54-R213) [[2]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fR222-R348)

**General Codebase Improvements:**

* Replaced usage of `ConcurrentHashMap` and other standard collections with fastutil collections for improved performance and memory usage in handler storage.
* Improved event listener logic to check for the presence of handlers before processing, further reducing overhead when no handlers are registered.

These changes collectively make the lore packet handling system more robust, efficient, and maintainable, especially in environments with multiple plugins registering lore handlers.

**References:** [[1]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fL20-R45) [[2]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fR222-R348) [[3]](diffhunk://#diff-1988dd2fcd88ad00caa30f8bc67da90d4b96d3c2a3a2dfec29b0ec5d80151deaR39-R46) [[4]](diffhunk://#diff-1988dd2fcd88ad00caa30f8bc67da90d4b96d3c2a3a2dfec29b0ec5d80151deaL52-R69) [[5]](diffhunk://#diff-c14aeb6e8383ef3252e6bdd26136a08e2f455da490ab50ae6af8217ecf3f9ebdR18-R22) [[6]](diffhunk://#diff-e1eaa0afddbcb7890fca4b83c93650693728256671e5855c7b90710925047e4eR1-R13) [[7]](diffhunk://#diff-5c854fc015902121b16c77102806b42027bed61922a911bfd0d0c9f95289e612R29-R36) [[8]](diffhunk://#diff-48de1417a8880d5ee0684a49e6d30abda976cfe135a3c58fe0b2a6872a3fbe4fR54-R213)