### PR TITLE
Refactor dirty block management with ConcurrentHashMap and version bump

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.70.0
+version=1.21.11-2.70.1
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/pdc/block/BlockPdcManager.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/impl/pdc/block/BlockPdcManager.kt
@@ -26,15 +26,15 @@ import com.github.shynixn.mccoroutine.folia.globalRegionDispatcher
 import com.github.shynixn.mccoroutine.folia.launch
 import com.github.shynixn.mccoroutine.folia.ticks
 import dev.slne.surf.surfapi.bukkit.server.plugin
-import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import io.papermc.paper.math.BlockPosition
 import kotlinx.coroutines.delay
 import org.bukkit.block.Block
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 
 object BlockPdcManager {
-    private val dirtyBlocks = mutableObjectSetOf<Pair<UUID, BlockPosition>>()
+    private val dirtyBlocks = ConcurrentHashMap.newKeySet<Pair<UUID, BlockPosition>>()
 
     fun isDirty(block: Block): Boolean {
         val entry = getEntry(block)


### PR DESCRIPTION
This pull request includes a version bump and an internal improvement to how dirty blocks are tracked in the `BlockPdcManager`. The most significant change is the replacement of a custom mutable set with a thread-safe concurrent set for managing dirty blocks, which increases safety in concurrent environments.

**Version update:**

* Incremented the project version in `gradle.properties` from `1.21.11-2.70.0` to `1.21.11-2.70.1`.

**Thread safety improvement:**

* Replaced the use of `mutableObjectSetOf` with `ConcurrentHashMap.newKeySet` for the `dirtyBlocks` set in `BlockPdcManager`, ensuring thread-safe access and modification.