### PR TITLE
Fix state ID issues by handling container click packets

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.71.0
+version=1.21.11-2.71.1
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
+++ b/surf-api-bukkit/surf-api-bukkit-server/src/main/kotlin/dev/slne/surf/surfapi/bukkit/server/packet/lore/PacketLoreListener.kt
@@ -15,6 +15,7 @@ import it.unimi.dsi.fastutil.objects.ObjectLists
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
 import net.minecraft.network.protocol.game.*
+import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.ItemStack
 import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.item.component.ItemLore
@@ -118,6 +119,35 @@ object PacketLoreListener : PacketListener {
         return ClientboundSetPlayerInventoryPacket(
             event.slot(),
             updated
+        )
+    }
+
+    @ServerboundListener
+    fun onContainerClickPacket(
+        event: ServerboundContainerClickPacket,
+        player: ServerPlayer
+    ): ServerboundContainerClickPacket {
+        if (!hasAnyHandlers()) return event
+
+        val container = player.containerMenu
+        val currentStateId = container.stateId
+
+        val brokenStateId = if (event.stateId() == currentStateId) {
+            currentStateId - 1
+        } else {
+            event.stateId()
+        }
+
+        if (brokenStateId == event.stateId()) return event
+
+        return ServerboundContainerClickPacket(
+            event.containerId(),
+            brokenStateId,
+            event.slotNum(),
+            event.buttonNum(),
+            event.clickType(),
+            event.changedSlots(),
+            event.carriedItem()
         )
     }
 


### PR DESCRIPTION
This pull request introduces a minor version bump and adds a new packet handler to the `PacketLoreListener` in the Bukkit server module. The main focus is on improving how container click packets are processed, likely to address an issue with state IDs.

Version bump:

* Updated the project version in `gradle.properties` from `1.21.11-2.71.0` to `1.21.11-2.71.1`.

Packet handling improvements:

* Added a new `onContainerClickPacket` method to `PacketLoreListener` that intercepts `ServerboundContainerClickPacket` packets, checks for mismatched container state IDs, and adjusts the state ID if necessary to prevent issues.
* Imported `ServerPlayer` to support the new packet handler logic.