### PR TITLE
Bump plugin and library versions to 1.21.11-2.71.2

### DIFF
--- a/buildSrc/src/main/kotlin/java-toolchain-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/java-toolchain-convention.gradle.kts
@@ -1,4 +1,3 @@
-import gradle.kotlin.dsl.accessors._bcd9a993373509de50154c5485fe667f.java
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 
 val javaVersion: String by project

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.71.1
+version=1.21.11-2.71.2
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ canvas-api = "1.21.11-R0.1-SNAPSHOT"
 hytale-server = "1.0.0"
 
 # Kolin
-kotlinVersion = "2.3.10"
+kotlinVersion = "2.3.20"
 kotlinxCoroutines = "1.10.2"
 kotlinx-serialization = "1.10.0"
 
@@ -22,8 +22,8 @@ commandapi = "11.1.0"
 luckperms = "v5.5.0-bukkit"
 
 # Scoreboard Library
-scoreboard-library = "2.7.0"
-scoreboard-library-implementation = "2.7.0"
+scoreboard-library = "2.7.1"
+scoreboard-library-implementation = "2.7.1"
 
 # Adventure
 adventure-api = "4.26.1"
@@ -70,7 +70,7 @@ bytebuddy = "1.18.7"
 
 # Plugin versions
 maven-repo-auth = "3.0.4"
-shadow-gradle-plugin = "9.3.2"
+shadow-gradle-plugin = "9.4.1"
 run-paper-gradle-plugin = "3.0.2"
 dokka = "2.1.0"
 

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -13,7 +13,7 @@ plugins {
     `kotlin-dsl`
     `java-toolchain-convention`
 
-    id("com.gradle.plugin-publish") version "2.1.0"
+    id("com.gradle.plugin-publish") version "2.1.1"
     kotlin("plugin.serialization")
     idea
 }


### PR DESCRIPTION
This pull request mainly updates several dependencies and plugins to their latest versions, as well as increments the project version. These changes help keep the project up-to-date, improve compatibility, and may include important bug fixes or performance improvements.

Dependency and plugin updates:

* Updated `kotlinVersion` to `2.3.20` in `gradle/libs.versions.toml` to use the latest Kotlin version.
* Updated `scoreboard-library` and its implementation to `2.7.1` in `gradle/libs.versions.toml`.
* Updated `shadow-gradle-plugin` to `9.4.1` in `gradle/libs.versions.toml`.
* Updated `com.gradle.plugin-publish` plugin to `2.1.1` in `surf-api-gradle-plugin/build.gradle.kts`.

Project version bump:

* Incremented project `version` from `1.21.11-2.71.1` to `1.21.11-2.71.2` in `gradle.properties`.

Minor cleanup:

* Removed an unused import from `buildSrc/src/main/kotlin/java-toolchain-convention.gradle.kts`.