### PR TITLE
Update version to 1.21.11-2.72.1 and correct config path documentation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=1.21.11
 group=dev.slne.surf
-version=1.21.11-2.72.0
+version=1.21.11-2.72.1
 relocationPrefix=dev.slne.surf.surfapi.libs
 snapshot=false

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/config/SpongeConfigClass.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/config/SpongeConfigClass.kt
@@ -112,7 +112,7 @@ sealed class SpongeConfigClass<C>(
     /**
      * Sets the path in the config file where the version number is stored.
      *
-     * Defaults to `"config-version"`. Call this in the `init` block before
+     * Defaults to `"_config_version"`. Call this in the `init` block before
      * any migration registrations if you need a custom key.
      *
      * @param path the path components to the version key

--- a/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/config/SurfConfigApi.kt
+++ b/surf-api-core/surf-api-core-api/src/main/kotlin/dev/slne/surf/surfapi/core/api/config/SurfConfigApi.kt
@@ -129,7 +129,7 @@ interface SurfConfigApi {
         configFolder: Path,
         configFileName: @JsonConfigFileNamePattern String,
     ): SpongeConfigManager<C> =
-        createSpongeYmlConfigManager(configClass, configFolder, configFileName, ConfigMigrationBuilder())
+        createSpongeJsonConfigManager(configClass, configFolder, configFileName, ConfigMigrationBuilder())
 
     /**
      * Creates a Sponge JSON configuration manager.


### PR DESCRIPTION
This pull request introduces a version bump and fixes a critical configuration manager instantiation bug, along with a documentation update for config versioning. The most important changes are:

Versioning and release:

* Bumped the project version from `1.21.11-2.72.0` to `1.21.11-2.72.1` in `gradle.properties` to reflect the new release.

Configuration management:

* Fixed a bug in `SurfConfigApi` where the `createConfigManager` method was incorrectly calling `createSpongeYmlConfigManager` instead of `createSpongeJsonConfigManager`, ensuring the correct configuration manager is used for JSON configs.

Documentation:

* Updated the documentation in `SpongeConfigClass` to reflect that the default config version key is now `"_config_version"` instead of `"config-version"`.