### PR TITLE
Bump version to 3.0.4 and update McCoroutine to 2.22.2

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.0.3
+version=3.0.4
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ velocity-api = "3.5.0-SNAPSHOT"
 placeholder-api = "2.12.2"
 
 # McCoroutine
-mccoroutine = "2.22.0"
+mccoroutine = "2.22.2"
 
 # Miscellaneous Libraries
 guava = "33.5.0-jre"
@@ -120,10 +120,10 @@ velocity-api = { module = "com.velocitypowered:velocity-api", version.ref = "vel
 placeholder-api = { module = "me.clip:placeholderapi", version.ref = "placeholder-api" }
 
 # McCoroutine
-mccoroutine-folia-api = { module = "com.github.shynixn.mccoroutine:mccoroutine-folia-api", version.ref = "mccoroutine" }
-mccoroutine-folia-core = { module = "com.github.shynixn.mccoroutine:mccoroutine-folia-core", version.ref = "mccoroutine" }
-mccoroutine-velocity-api = { module = "com.github.shynixn.mccoroutine:mccoroutine-velocity-api", version.ref = "mccoroutine" }
-mccoroutine-velocity-core = { module = "com.github.shynixn.mccoroutine:mccoroutine-velocity-core", version.ref = "mccoroutine" }
+mccoroutine-folia-api = { module = "dev.slne.forks.mccoroutine:mccoroutine-folia-api", version.ref = "mccoroutine" }
+mccoroutine-folia-core = { module = "dev.slne.forks.mccoroutine:mccoroutine-folia-core", version.ref = "mccoroutine" }
+mccoroutine-velocity-api = { module = "dev.slne.forks.mccoroutine:mccoroutine-velocity-api", version.ref = "mccoroutine" }
+mccoroutine-velocity-core = { module = "dev.slne.forks.mccoroutine:mccoroutine-velocity-core", version.ref = "mccoroutine" }
 
 # Miscellaneous Libraries
 guava = { module = "com.google.guava:guava", version.ref = "guava" }


### PR DESCRIPTION
This pull request updates the project version and makes changes to the McCoroutine dependencies, including switching to a forked version and bumping the library version. These updates are primarily dependency and version management improvements.

Dependency updates:

* Updated the `mccoroutine` library version from `2.22.0` to `2.22.2` in `gradle/libs.versions.toml`.
* Changed the `mccoroutine` dependencies to use the `dev.slne.forks.mccoroutine` fork instead of `com.github.shynixn.mccoroutine` in `gradle/libs.versions.toml`.

Versioning:

* Bumped the project version from `3.0.3` to `3.0.4` in `gradle.properties`.