### PR TITLE
Update scoreboard-library reference and bump version to 3.0.9

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.0.8
+version=3.0.9
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,6 @@ luckperms = "v5.5.0-bukkit"
 
 # Scoreboard Library
 scoreboard-library = "2.7.3"
-scoreboard-library-implementation = "2.7.1"
 
 # Adventure
 adventure-api = "4.26.1"
@@ -101,7 +100,7 @@ commandapi-velocity-kotlin = { module = "dev.jorel:commandapi-kotlin-velocity", 
 
 # Scoreboard Library
 scoreboard-library-api = { module = "net.megavex:scoreboard-library-api", version.ref = "scoreboard-library" }
-scoreboard-library-implementation = { module = "net.megavex:scoreboard-library-implementation", version.ref = "scoreboard-library-implementation" }
+scoreboard-library-implementation = { module = "net.megavex:scoreboard-library-implementation", version.ref = "scoreboard-library" }
 
 # Adventure
 adventure-api = { module = "net.kyori:adventure-api", version.ref = "adventure-api" }


### PR DESCRIPTION
This pull request makes a minor update to the project version and fixes a dependency version reference for the scoreboard library implementation.

Dependency management improvements:

* Updated the `scoreboard-library-implementation` dependency in `gradle/libs.versions.toml` to use the same version as `scoreboard-library`, ensuring consistency between API and implementation.
* Removed the separate `scoreboard-library-implementation` version entry from `gradle/libs.versions.toml`, as it's now unified with the main library version.

Project versioning:

* Bumped the project version from `3.0.8` to `3.0.9` in `gradle.properties`.