### PR TITLE
Update dependencies and bump version to 3.1.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.1.0
+version=3.1.1
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ canvas-api = "1.21.11-R0.1-SNAPSHOT"
 # Kolin
 kotlinVersion = "2.3.20"
 kotlinxCoroutines = "1.10.2"
-kotlinx-serialization = "1.10.0"
+kotlinx-serialization = "1.11.0"
 
 # Packet Events
 packetevents = "2.11.2"
@@ -19,7 +19,7 @@ commandapi = "11.2.0"
 luckperms = "5.4"
 
 # Scoreboard Library
-scoreboard-library = "2.7.3"
+scoreboard-library = "2.7.4"
 
 # Adventure
 adventure-api = "4.26.1"
@@ -67,7 +67,7 @@ bytebuddy = "1.18.8"
 maven-repo-auth = "3.0.4"
 shadow-gradle-plugin = "9.4.1"
 run-paper-gradle-plugin = "3.0.2"
-dokka = "2.1.0"
+dokka = "2.2.0"
 
 [libraries]
 # Paper

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradlew
+++ b/gradlew
@@ -57,7 +57,7 @@
 #       Darwin, MinGW, and NonStop.
 #
 #   (3) This script is generated from the Groovy template
-#       https://github.com/gradle/gradle/blob/b631911858264c0b6e4d6603d677ff5218766cee/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
+#       https://github.com/gradle/gradle/blob/2d6327017519d23b96af35865dc997fcb544fb40/platforms/jvm/plugins-application/src/main/resources/org/gradle/api/internal/plugins/unixStartScript.txt
 #       within the Gradle project.
 #
 #       You can find Gradle at https://github.com/gradle/gradle/.

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     compileOnly(gradleApi())
     pluginDependencies.forEach { dep -> api(dep) }
 
-    implementation("com.palantir.javapoet:javapoet:0.12.0")
+    implementation("com.palantir.javapoet:javapoet:0.14.0")
     implementation(libs.bundles.kotlin.serialization)
 }
 


### PR DESCRIPTION
This pull request primarily updates several dependencies and tools to their latest versions, ensuring improved stability, compatibility, and access to new features. The changes affect both project plugins and libraries, as well as the Gradle build system.

Dependency and plugin updates:

* Upgraded `kotlinx-serialization` to version `1.11.0` for improved serialization features and bug fixes.
* Updated `scoreboard-library` to version `2.7.4` for the latest scoreboard functionality.
* Bumped `dokka` documentation tool to version `2.2.0` for enhanced documentation generation.
* Upgraded `com.palantir.javapoet:javapoet` to version `0.14.0` in the Gradle plugin for improved Java code generation capabilities.

Build system updates:

* Updated Gradle wrapper to version `9.4.1` for the latest build performance and fixes, and updated the associated `gradlew` script reference. [[1]](diffhunk://#diff-40640fe1078ece83d7ea8fb67daacd77923a86d13447baf9769660b3b46f2eceL3-R3) [[2]](diffhunk://#diff-e9721dc750619a21053ddea8a5d04929a608877d8c5daec1b57d243d3424e745L60-R60)

Project versioning:

* Incremented the project version to `3.1.1` in `gradle.properties` to reflect these updates.