### PR TITLE
Fix: NPE in config api companion object

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.2.2
+version=3.2.3
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SurfConfigApi.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SurfConfigApi.kt
@@ -154,7 +154,7 @@ interface SurfConfigApi {
 /**
  * Retrieves the singleton instance of [SurfConfigApi].
  */
-val surfConfigApi = requiredService<SurfConfigApi>()
+val surfConfigApi by lazy { requiredService<SurfConfigApi>() }
 
 /**
  * Creates a Sponge YAML configuration using a reified type.


### PR DESCRIPTION
This pull request contains a minor version update and a small improvement to how the `surfConfigApi` singleton is initialized. The changes are straightforward and focus on improving initialization safety and updating the project version.

- Versioning:
  * Bumped the project version from `3.2.2` to `3.2.3` in `gradle.properties`.

- Initialization improvement:
  * Changed the initialization of `surfConfigApi` to use Kotlin's `by lazy` delegate, ensuring it is only created when first accessed, in `SurfConfigApi.kt`.