### PR TITLE
Add system chat packet transformation for item lore handling

### DIFF
--- a/.run/Run Paper Test Server.run.xml
+++ b/.run/Run Paper Test Server.run.xml
@@ -1,0 +1,27 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run Paper Test Server" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="--stacktrace" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value=":surf-api-paper:surf-api-paper-plugin-test:runServer" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>true</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <ExternalSystemDebugDisabled>false</ExternalSystemDebugDisabled>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <GradleProfilingDisabled>false</GradleProfilingDisabled>
+    <GradleCoverageDisabled>false</GradleCoverageDisabled>
+    <method v="2" />
+  </configuration>
+</component>

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.3.0
+version=3.3.1
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
@@ -178,6 +178,37 @@ object V1_21_11PacketLoreListener : PacketListener {
         return ClientboundSystemChatPacket(transformed, event.overlay())
     }
 
+    @ClientboundListener
+    fun onClientboundPlayerChatPacket(event: ClientboundPlayerChatPacket): ClientboundPlayerChatPacket {
+        if (!hasAnyHandlers()) return event
+        val unsignedContent = event.unsignedContent() ?: return event
+        val transformed = transformChatComponent(unsignedContent)
+
+        if (transformed === unsignedContent) return event
+
+        return ClientboundPlayerChatPacket(
+            event.globalIndex(),
+            event.sender(),
+            event.index(),
+            event.signature(),
+            event.body(),
+            transformed,
+            event.filterMask(),
+            event.chatType()
+        )
+    }
+
+    @ClientboundListener
+    fun onClientboundDisguisedChatPacket(event: ClientboundDisguisedChatPacket): ClientboundDisguisedChatPacket {
+        if (!hasAnyHandlers()) return event
+        val message = event.message()
+        val transformed = transformChatComponent(message)
+
+        if (transformed === message) return event
+
+        return ClientboundDisguisedChatPacket(transformed, event.chatType())
+    }
+
     /**
      * Recursively walks the component tree and rebuilds only the branches that actually
      * contain a [HoverEvent.ShowItem] whose item lore is mutated by the registered handlers.

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
@@ -14,6 +14,8 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet
 import it.unimi.dsi.fastutil.objects.ObjectLists
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.Style
 import net.minecraft.network.protocol.game.*
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.ItemStack
@@ -162,6 +164,79 @@ object V1_21_11PacketLoreListener : PacketListener {
         }
 
         return ClientboundSetCursorItemPacket(updated)
+    }
+
+    @ClientboundListener
+    fun onSystemChatPacket(event: ClientboundSystemChatPacket): ClientboundSystemChatPacket {
+        if (!hasAnyHandlers()) return event
+
+        val original = event.content()
+        val transformed = transformChatComponent(original)
+
+        if (transformed === original) return event
+
+        return ClientboundSystemChatPacket(transformed, event.overlay())
+    }
+
+    /**
+     * Recursively walks the component tree and rebuilds only the branches that actually
+     * contain a [HoverEvent.ShowItem] whose item lore is mutated by the registered handlers.
+     *
+     * Returns the same [component] reference if nothing changed, so the caller can short-circuit.
+     */
+    private fun transformChatComponent(component: MinecraftComponent): MinecraftComponent {
+        val style = component.style
+        val newStyle = transformStyle(style)
+
+        val siblings = component.siblings
+        var newSiblings: ObjectArrayList<MinecraftComponent>? = null
+
+        for (i in siblings.indices) {
+            val sibling = siblings[i]
+            val transformedSibling = transformChatComponent(sibling)
+
+            if (transformedSibling !== sibling && newSiblings == null) {
+                newSiblings = ObjectArrayList(siblings.size)
+                for (j in 0 until i) {
+                    newSiblings.add(siblings[j])
+                }
+            }
+
+            newSiblings?.add(transformedSibling)
+        }
+
+        if (newStyle === style && newSiblings == null) {
+            return component
+        }
+
+        val copy = component.copy()
+        if (newStyle !== style) {
+            copy.style = newStyle
+        }
+
+        if (newSiblings != null) {
+            val target = copy.siblings
+            target.clear()
+            target.addAll(newSiblings)
+        }
+
+        return copy
+    }
+
+    /**
+     * Applies the lore handlers to the item carried by a [HoverEvent.ShowItem], if any.
+     * Returns the original [style] reference when nothing changed.
+     */
+    private fun transformStyle(style: Style): Style {
+        val hoverEvent = style.hoverEvent ?: return style
+        if (hoverEvent !is HoverEvent.ShowItem) return style
+
+        val stack = hoverEvent.item
+        val updated = makeUpdatedItemStack(stack)
+
+        if (updated === stack) return style
+
+        return style.withHoverEvent(HoverEvent.ShowItem(stack))
     }
 
     /**

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
@@ -236,7 +236,7 @@ object V1_21_11PacketLoreListener : PacketListener {
 
         if (updated === stack) return style
 
-        return style.withHoverEvent(HoverEvent.ShowItem(stack))
+        return style.withHoverEvent(HoverEvent.ShowItem(updated))
     }
 
     /**

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
@@ -14,9 +14,12 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet
 import it.unimi.dsi.fastutil.objects.ObjectLists
 import net.kyori.adventure.text.format.TextDecoration
 import net.minecraft.core.component.DataComponents
+import net.minecraft.network.chat.HoverEvent
+import net.minecraft.network.chat.Style
 import net.minecraft.network.protocol.game.*
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.item.ItemStack
+import net.minecraft.world.item.ItemStackTemplate
 import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.item.component.ItemLore
 import org.bukkit.NamespacedKey
@@ -163,6 +166,86 @@ object V26_1PacketLoreListener : PacketListener {
         }
 
         return ClientboundSetCursorItemPacket(updated)
+    }
+
+    @ClientboundListener
+    fun onSystemChatPacket(event: ClientboundSystemChatPacket): ClientboundSystemChatPacket {
+        if (!hasAnyHandlers()) return event
+
+        val original = event.content()
+        val transformed = transformChatComponent(original)
+
+        if (transformed === original) return event
+
+        return ClientboundSystemChatPacket(transformed, event.overlay())
+    }
+
+    /**
+     * Recursively walks the component tree and rebuilds only the branches that actually
+     * contain a [HoverEvent.ShowItem] whose item lore is mutated by the registered handlers.
+     *
+     * Returns the same [component] reference if nothing changed, so the caller can short-circuit.
+     */
+    private fun transformChatComponent(component: MinecraftComponent): MinecraftComponent {
+        val style = component.style
+        val newStyle = transformStyle(style)
+
+        val siblings = component.siblings
+        var newSiblings: ObjectArrayList<MinecraftComponent>? = null
+
+        for (i in siblings.indices) {
+            val sibling = siblings[i]
+            val transformedSibling = transformChatComponent(sibling)
+
+            if (transformedSibling !== sibling && newSiblings == null) {
+                newSiblings = ObjectArrayList(siblings.size)
+                for (j in 0 until i) {
+                    newSiblings.add(siblings[j])
+                }
+            }
+
+            newSiblings?.add(transformedSibling)
+        }
+
+        if (newStyle === style && newSiblings == null) {
+            return component
+        }
+
+        val copy = component.copy()
+        if (newStyle !== style) {
+            copy.style = newStyle
+        }
+
+        if (newSiblings != null) {
+            val target = copy.siblings
+            target.clear()
+            target.addAll(newSiblings)
+        }
+
+        return copy
+    }
+
+    /**
+     * Applies the lore handlers to the item carried by a [HoverEvent.ShowItem], if any.
+     * Returns the original [style] reference when nothing changed.
+     */
+    private fun transformStyle(style: Style): Style {
+        val hoverEvent = style.hoverEvent ?: return style
+        if (hoverEvent !is HoverEvent.ShowItem) return style
+
+        val template = hoverEvent.item
+        val stack = ItemStack(template.item, template.count, template.components)
+        val updated = makeUpdatedItemStack(stack)
+
+        if (updated === stack) return style
+
+        val newTemplate = ItemStackTemplate(
+            updated.typeHolder(),
+            updated.count,
+            updated.componentsPatch
+        )
+
+        return style.withHoverEvent(HoverEvent.ShowItem(newTemplate))
     }
 
     /**

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
@@ -248,6 +248,37 @@ object V26_1PacketLoreListener : PacketListener {
         return style.withHoverEvent(HoverEvent.ShowItem(newTemplate))
     }
 
+    @ClientboundListener
+    fun onClientboundPlayerChatPacket(event: ClientboundPlayerChatPacket): ClientboundPlayerChatPacket {
+        if (!hasAnyHandlers()) return event
+        val unsignedContent = event.unsignedContent() ?: return event
+        val transformed =transformChatComponent(unsignedContent)
+
+        if (transformed === unsignedContent) return event
+
+        return ClientboundPlayerChatPacket(
+            event.globalIndex(),
+            event.sender(),
+            event.index(),
+            event.signature(),
+            event.body(),
+            transformed,
+            event.filterMask(),
+            event.chatType()
+        )
+    }
+
+    @ClientboundListener
+    fun onClientboundDisguisedChatPacket(event: ClientboundDisguisedChatPacket): ClientboundDisguisedChatPacket {
+        if (!hasAnyHandlers()) return event
+        val message = event.message()
+        val transformed = transformChatComponent(message)
+
+        if (transformed === message) return event
+
+        return ClientboundDisguisedChatPacket(transformed, event.chatType())
+    }
+
     /**
      * Returns the original item if:
      * - item is empty

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
@@ -180,6 +180,37 @@ object V26_1PacketLoreListener : PacketListener {
         return ClientboundSystemChatPacket(transformed, event.overlay())
     }
 
+    @ClientboundListener
+    fun onClientboundPlayerChatPacket(event: ClientboundPlayerChatPacket): ClientboundPlayerChatPacket {
+        if (!hasAnyHandlers()) return event
+        val unsignedContent = event.unsignedContent() ?: return event
+        val transformed =transformChatComponent(unsignedContent)
+
+        if (transformed === unsignedContent) return event
+
+        return ClientboundPlayerChatPacket(
+            event.globalIndex(),
+            event.sender(),
+            event.index(),
+            event.signature(),
+            event.body(),
+            transformed,
+            event.filterMask(),
+            event.chatType()
+        )
+    }
+
+    @ClientboundListener
+    fun onClientboundDisguisedChatPacket(event: ClientboundDisguisedChatPacket): ClientboundDisguisedChatPacket {
+        if (!hasAnyHandlers()) return event
+        val message = event.message()
+        val transformed = transformChatComponent(message)
+
+        if (transformed === message) return event
+
+        return ClientboundDisguisedChatPacket(transformed, event.chatType())
+    }
+
     /**
      * Recursively walks the component tree and rebuilds only the branches that actually
      * contain a [HoverEvent.ShowItem] whose item lore is mutated by the registered handlers.
@@ -246,37 +277,6 @@ object V26_1PacketLoreListener : PacketListener {
         )
 
         return style.withHoverEvent(HoverEvent.ShowItem(newTemplate))
-    }
-
-    @ClientboundListener
-    fun onClientboundPlayerChatPacket(event: ClientboundPlayerChatPacket): ClientboundPlayerChatPacket {
-        if (!hasAnyHandlers()) return event
-        val unsignedContent = event.unsignedContent() ?: return event
-        val transformed =transformChatComponent(unsignedContent)
-
-        if (transformed === unsignedContent) return event
-
-        return ClientboundPlayerChatPacket(
-            event.globalIndex(),
-            event.sender(),
-            event.index(),
-            event.signature(),
-            event.body(),
-            transformed,
-            event.filterMask(),
-            event.chatType()
-        )
-    }
-
-    @ClientboundListener
-    fun onClientboundDisguisedChatPacket(event: ClientboundDisguisedChatPacket): ClientboundDisguisedChatPacket {
-        if (!hasAnyHandlers()) return event
-        val message = event.message()
-        val transformed = transformChatComponent(message)
-
-        if (transformed === message) return event
-
-        return ClientboundDisguisedChatPacket(transformed, event.chatType())
     }
 
     /**

--- a/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
+++ b/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
@@ -41,8 +41,6 @@ paper {
 }
 
 tasks {
-
-
     runServer {
         dependsOn(":surf-api-paper:surf-api-paper-server:shadowJar")
         pluginJars.from(project(":surf-api-paper:surf-api-paper-server").tasks.shadowJar)

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
@@ -27,7 +27,8 @@ public class SurfApiTestCommand extends CommandAPICommand {
                 new ToastTest("toast"),
                 new SuspendCommandExecutionTest("suspendCommandExecution"),
                 new SummonCommandTest("summoncommand"),
-                new SurfEventHandlerTest("eventhandler")
+                new SurfEventHandlerTest("eventhandler"),
+                new ShowItemCommand("showitem")
         );
     }
 }

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/ShowItemCommand.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/ShowItemCommand.kt
@@ -1,0 +1,20 @@
+package dev.slne.surf.surfapi.bukkit.test.command.subcommands
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.api.core.messages.adventure.sendText
+
+class ShowItemCommand(name: String) : CommandAPICommand(name) {
+    init {
+        playerExecutor { player, arguments ->
+            val item = player.inventory.itemInMainHand
+            player.sendText {
+                info("Item in hand: ")
+                append {
+                    append(item.displayName())
+                    hoverEvent(item)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This pull request introduces a new test command and improves item hover event handling in chat components for both Minecraft 1.21.11 and 26.1 NMS implementations. It also bumps the project version and adds a run configuration for testing. The main focus is enabling proper mutation and display of item lore in system chat packets, which is essential for features like hoverable item tooltips in chat.

**Enhancements to item hover and chat handling:**

* Added logic to recursively transform chat components in system chat packets, so that item hover events (`HoverEvent.ShowItem`) reflect any lore modifications made by registered handlers. This ensures that when items are shown in chat, their lore can be dynamically altered before display. (`V1_21_11PacketLoreListener.kt`, `V26_1PacketLoreListener.kt`) [[1]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2R169-R241) [[2]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400R171-R250)
* For 26.1, properly reconstructs `ItemStackTemplate` after lore mutation to maintain compatibility with the new item system. (`V26_1PacketLoreListener.kt`)

**Testing and developer tooling:**

* Added a new `ShowItemCommand` test command, which lets a player display the item in their hand (with hover event) in chat for testing purposes. (`ShowItemCommand.kt`, `SurfApiTestCommand.java`) [[1]](diffhunk://#diff-5564bf778c65c955ace0fdd5b91242d0e07116b0356cc3285f2405798ae1ff1fR1-R20) [[2]](diffhunk://#diff-55d4e84be3738641b06fcd462c85e60b18dbbfc2c25ed5658d6fc7a9d990e98eL30-R31)
* Added a Gradle run configuration file for easily running the Paper test server in development. (`.run/Run Paper Test Server.run.xml`)

**Project versioning:**

* Bumped the project version from `3.3.0` to `3.3.1`. (`gradle.properties`)

These changes collectively improve the developer experience and ensure that item hover events in chat are correctly processed and testable.