### PR TITLE
Add priority support for packet lore listeners and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.3.1
+version=3.4.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/PacketLoreRegistry.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/PacketLoreRegistry.kt
@@ -11,8 +11,8 @@ import org.bukkit.plugin.Plugin
  * its version-specific packet lore listener.
  */
 interface PacketLoreRegistry {
-    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler)
-    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler)
+    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler, priority: Short)
+    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler, priority: Short)
     fun unregister(identifier: NamespacedKey)
     fun unregister(plugin: Plugin)
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreListener.kt
@@ -23,6 +23,7 @@ import net.minecraft.world.item.component.CustomData
 import net.minecraft.world.item.component.ItemLore
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
+import java.util.*
 import net.minecraft.network.chat.Component as MinecraftComponent
 
 /**
@@ -31,17 +32,25 @@ import net.minecraft.network.chat.Component as MinecraftComponent
  */
 @OptIn(NmsUseWithCaution::class)
 object V1_21_11PacketLoreListener : PacketListener {
+    private data class PriorityHandler(
+        val handler: SurfPaperPacketLoreHandler,
+        val priority: Short,
+    )
+
+    private val priorityComparator =
+        Comparator<PriorityHandler> { a, b -> a.priority.compareTo(b.priority) }
+
     private val globalHandlersByPlugin =
-        Object2ObjectLinkedOpenHashMap<Plugin, ObjectLinkedOpenHashSet<SurfPaperPacketLoreHandler>>()
+        Object2ObjectLinkedOpenHashMap<Plugin, ObjectLinkedOpenHashSet<PriorityHandler>>()
 
     private val keyedHandlersByPlugin =
-        Object2ObjectLinkedOpenHashMap<Plugin, Object2ObjectLinkedOpenHashMap<NamespacedKey, SurfPaperPacketLoreHandler>>()
+        Object2ObjectLinkedOpenHashMap<Plugin, Object2ObjectLinkedOpenHashMap<NamespacedKey, PriorityHandler>>()
 
     @Volatile
-    private var keyedHandlersSnapshot: Map<NamespacedKey, SurfPaperPacketLoreHandler> = emptyMap()
+    private var keyedHandlersSnapshot: Map<NamespacedKey, PriorityHandler> = emptyMap()
 
     @Volatile
-    private var globalHandlersSnapshot: Array<SurfPaperPacketLoreHandler> = emptyArray()
+    private var globalHandlersSnapshot: Array<PriorityHandler> = emptyArray()
 
     private val ORIGINAL_LORE_KEY = namespacedKey("original_lore")
     private val ORIGINAL_LORE_KEY_STRING = ORIGINAL_LORE_KEY.asString()
@@ -327,12 +336,22 @@ object V1_21_11PacketLoreListener : PacketListener {
             ObjectArrayList(originalLines.size)
         ) { it.toBukkit() }
 
-        for (i in matchingKeyedHandlers.indices) {
-            matchingKeyedHandlers[i].handleLore(mutableLore, pdc, bukkitStack)
+        /*
+         * Combine matching keyed handlers and global handlers, then sort by priority so that
+         * smaller priority values run earlier and larger values run later — across both
+         * keyed and global handlers.
+         */
+        val combined = ObjectArrayList<PriorityHandler>(matchingKeyedHandlers.size + globalSnapshot.size)
+        combined.addAll(matchingKeyedHandlers)
+        for (i in globalSnapshot.indices) {
+            combined.add(globalSnapshot[i])
+        }
+        if (combined.size > 1) {
+            combined.sortWith(priorityComparator)
         }
 
-        for (i in globalSnapshot.indices) {
-            globalSnapshot[i].handleLore(mutableLore, pdc, bukkitStack)
+        for (i in combined.indices) {
+            combined[i].handler.handleLore(mutableLore, pdc, bukkitStack)
         }
 
         val updatedLines = ObjectArrayList<MinecraftComponent>(mutableLore.size)
@@ -383,13 +402,13 @@ object V1_21_11PacketLoreListener : PacketListener {
 
     private fun resolveMatchingKeyedHandlers(
         itemKeys: Set<NamespacedKey>,
-        keyedSnapshot: Map<NamespacedKey, SurfPaperPacketLoreHandler>,
-    ): List<SurfPaperPacketLoreHandler> {
+        keyedSnapshot: Map<NamespacedKey, PriorityHandler>,
+    ): List<PriorityHandler> {
         if (itemKeys.isEmpty() || keyedSnapshot.isEmpty()) {
             return emptyList()
         }
 
-        var result: ObjectArrayList<SurfPaperPacketLoreHandler>? = null
+        var result: ObjectArrayList<PriorityHandler>? = null
         for (key in itemKeys) {
             val handler = keyedSnapshot[key] ?: continue
 
@@ -403,7 +422,7 @@ object V1_21_11PacketLoreListener : PacketListener {
         return result ?: emptyList()
     }
 
-    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler) {
+    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler, priority: Short) {
         synchronized(this) {
             check(!keyedHandlersSnapshot.containsKey(identifier)) {
                 "A PacketLore handler for $identifier is already registered!"
@@ -412,26 +431,32 @@ object V1_21_11PacketLoreListener : PacketListener {
             val handlers =
                 keyedHandlersByPlugin.computeIfAbsent(plugin) { Object2ObjectLinkedOpenHashMap() }
 
-            val previous = handlers.putIfAbsent(identifier, listener)
+            val priorityHandler = PriorityHandler(listener, priority)
+            val previous = handlers.putIfAbsent(identifier, priorityHandler)
             check(previous == null) {
                 "A PacketLore handler for $identifier is already registered for plugin ${plugin.name}!"
             }
 
             val newSnapshot = Object2ObjectLinkedOpenHashMap(keyedHandlersSnapshot)
-            newSnapshot[identifier] = listener
+            newSnapshot[identifier] = priorityHandler
             keyedHandlersSnapshot = newSnapshot
         }
     }
 
-    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler) {
+    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler, priority: Short) {
         synchronized(this) {
             val handlers =
                 globalHandlersByPlugin.computeIfAbsent(plugin) { ObjectLinkedOpenHashSet() }
-            if (handlers.add(listener)) {
-                rebuildGlobalHandlersSnapshot()
-            } else {
-                error("A PacketLore handler identical to the provided one (${listener.javaClass.name}) is already registered for plugin ${plugin.name}!")
+
+            // duplicate-detection by handler identity, regardless of priority
+            for (existing in handlers) {
+                if (existing.handler === listener) {
+                    error("A PacketLore handler identical to the provided one (${listener.javaClass.name}) is already registered for plugin ${plugin.name}!")
+                }
             }
+
+            handlers.add(PriorityHandler(listener, priority))
+            rebuildGlobalHandlersSnapshot()
         }
     }
 
@@ -481,7 +506,7 @@ object V1_21_11PacketLoreListener : PacketListener {
     }
 
     private fun rebuildGlobalHandlersSnapshot() {
-        val snapshot = ObjectArrayList<SurfPaperPacketLoreHandler>()
+        val snapshot = ObjectArrayList<PriorityHandler>()
 
         globalHandlersByPlugin.object2ObjectEntrySet().fastForEach { (plugin, handlers) ->
             if (plugin.isEnabled) {
@@ -489,6 +514,10 @@ object V1_21_11PacketLoreListener : PacketListener {
             }
         }
 
-        globalHandlersSnapshot = snapshot.toTypedArray()
+        val array = snapshot.toTypedArray()
+        if (array.size > 1) {
+            Arrays.sort(array, priorityComparator)
+        }
+        globalHandlersSnapshot = array
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreRegistry.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/lore/V1_21_11PacketLoreRegistry.kt
@@ -6,12 +6,12 @@ import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
 
 class V1_21_11PacketLoreRegistry : PacketLoreRegistry {
-    override fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler) {
-        V1_21_11PacketLoreListener.register(plugin, identifier, listener)
+    override fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler, priority: Short) {
+        V1_21_11PacketLoreListener.register(plugin, identifier, listener, priority)
     }
 
-    override fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler) {
-        V1_21_11PacketLoreListener.register(plugin, listener)
+    override fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler, priority: Short) {
+        V1_21_11PacketLoreListener.register(plugin, listener, priority)
     }
 
     override fun unregister(identifier: NamespacedKey) {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreListener.kt
@@ -33,17 +33,25 @@ import net.minecraft.network.chat.Component as MinecraftComponent
 @OptIn(NmsUseWithCaution::class)
 @Suppress("ClassName")
 object V26_1PacketLoreListener : PacketListener {
+    private data class PriorityHandler(
+        val handler: SurfPaperPacketLoreHandler,
+        val priority: Short,
+    )
+
+    private val priorityComparator =
+        Comparator<PriorityHandler> { a, b -> a.priority.compareTo(b.priority) }
+
     private val globalHandlersByPlugin =
-        Object2ObjectLinkedOpenHashMap<Plugin, ObjectLinkedOpenHashSet<SurfPaperPacketLoreHandler>>()
+        Object2ObjectLinkedOpenHashMap<Plugin, ObjectLinkedOpenHashSet<PriorityHandler>>()
 
     private val keyedHandlersByPlugin =
-        Object2ObjectLinkedOpenHashMap<Plugin, Object2ObjectLinkedOpenHashMap<NamespacedKey, SurfPaperPacketLoreHandler>>()
+        Object2ObjectLinkedOpenHashMap<Plugin, Object2ObjectLinkedOpenHashMap<NamespacedKey, PriorityHandler>>()
 
     @Volatile
-    private var keyedHandlersSnapshot: Map<NamespacedKey, SurfPaperPacketLoreHandler> = emptyMap()
+    private var keyedHandlersSnapshot: Map<NamespacedKey, PriorityHandler> = emptyMap()
 
     @Volatile
-    private var globalHandlersSnapshot: Array<SurfPaperPacketLoreHandler> = emptyArray()
+    private var globalHandlersSnapshot: Array<PriorityHandler> = emptyArray()
 
     private val ORIGINAL_LORE_KEY = namespacedKey("original_lore")
     private val ORIGINAL_LORE_KEY_STRING = ORIGINAL_LORE_KEY.asString()
@@ -336,12 +344,22 @@ object V26_1PacketLoreListener : PacketListener {
             ObjectArrayList(originalLines.size)
         ) { it.toBukkit() }
 
-        for (i in matchingKeyedHandlers.indices) {
-            matchingKeyedHandlers[i].handleLore(mutableLore, pdc, bukkitStack)
+        /*
+         * Combine matching keyed handlers and global handlers, then sort by priority so that
+         * smaller priority values run earlier and larger values run later — across both
+         * keyed and global handlers.
+         */
+        val combined = ObjectArrayList<PriorityHandler>(matchingKeyedHandlers.size + globalSnapshot.size)
+        combined.addAll(matchingKeyedHandlers)
+        for (i in globalSnapshot.indices) {
+            combined.add(globalSnapshot[i])
+        }
+        if (combined.size > 1) {
+            combined.sortWith(priorityComparator)
         }
 
-        for (i in globalSnapshot.indices) {
-            globalSnapshot[i].handleLore(mutableLore, pdc, bukkitStack)
+        for (i in combined.indices) {
+            combined[i].handler.handleLore(mutableLore, pdc, bukkitStack)
         }
 
         val updatedLines = ObjectArrayList<MinecraftComponent>(mutableLore.size)
@@ -392,13 +410,13 @@ object V26_1PacketLoreListener : PacketListener {
 
     private fun resolveMatchingKeyedHandlers(
         itemKeys: Set<NamespacedKey>,
-        keyedSnapshot: Map<NamespacedKey, SurfPaperPacketLoreHandler>,
-    ): List<SurfPaperPacketLoreHandler> {
+        keyedSnapshot: Map<NamespacedKey, PriorityHandler>,
+    ): List<PriorityHandler> {
         if (itemKeys.isEmpty() || keyedSnapshot.isEmpty()) {
             return emptyList()
         }
 
-        var result: ObjectArrayList<SurfPaperPacketLoreHandler>? = null
+        var result: ObjectArrayList<PriorityHandler>? = null
         for (key in itemKeys) {
             val handler = keyedSnapshot[key] ?: continue
 
@@ -412,7 +430,7 @@ object V26_1PacketLoreListener : PacketListener {
         return result ?: emptyList()
     }
 
-    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler) {
+    fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler, priority: Short) {
         synchronized(this) {
             check(!keyedHandlersSnapshot.containsKey(identifier)) {
                 "A PacketLore handler for $identifier is already registered!"
@@ -421,26 +439,32 @@ object V26_1PacketLoreListener : PacketListener {
             val handlers =
                 keyedHandlersByPlugin.computeIfAbsent(plugin) { Object2ObjectLinkedOpenHashMap() }
 
-            val previous = handlers.putIfAbsent(identifier, listener)
+            val priorityHandler = PriorityHandler(listener, priority)
+            val previous = handlers.putIfAbsent(identifier, priorityHandler)
             check(previous == null) {
                 "A PacketLore handler for $identifier is already registered for plugin ${plugin.name}!"
             }
 
             val newSnapshot = Object2ObjectLinkedOpenHashMap(keyedHandlersSnapshot)
-            newSnapshot[identifier] = listener
+            newSnapshot[identifier] = priorityHandler
             keyedHandlersSnapshot = newSnapshot
         }
     }
 
-    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler) {
+    fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler, priority: Short) {
         synchronized(this) {
             val handlers =
                 globalHandlersByPlugin.computeIfAbsent(plugin) { ObjectLinkedOpenHashSet() }
-            if (handlers.add(listener)) {
-                rebuildGlobalHandlersSnapshot()
-            } else {
-                error("A PacketLore handler identical to the provided one (${listener.javaClass.name}) is already registered for plugin ${plugin.name}!")
+
+            // duplicate-detection by handler identity, regardless of priority
+            for (existing in handlers) {
+                if (existing.handler === listener) {
+                    error("A PacketLore handler identical to the provided one (${listener.javaClass.name}) is already registered for plugin ${plugin.name}!")
+                }
             }
+
+            handlers.add(PriorityHandler(listener, priority))
+            rebuildGlobalHandlersSnapshot()
         }
     }
 
@@ -490,7 +514,7 @@ object V26_1PacketLoreListener : PacketListener {
     }
 
     private fun rebuildGlobalHandlersSnapshot() {
-        val snapshot = ObjectArrayList<SurfPaperPacketLoreHandler>()
+        val snapshot = ObjectArrayList<PriorityHandler>()
 
         globalHandlersByPlugin.object2ObjectEntrySet().fastForEach { (plugin, handlers) ->
             if (plugin.isEnabled) {
@@ -498,6 +522,10 @@ object V26_1PacketLoreListener : PacketListener {
             }
         }
 
-        globalHandlersSnapshot = snapshot.toTypedArray()
+        val array = snapshot.toTypedArray()
+        if (array.size > 1) {
+            java.util.Arrays.sort(array, priorityComparator)
+        }
+        globalHandlersSnapshot = array
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreRegistry.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/lore/V26_1PacketLoreRegistry.kt
@@ -7,12 +7,12 @@ import org.bukkit.plugin.Plugin
 
 @Suppress("ClassName")
 class V26_1PacketLoreRegistry : PacketLoreRegistry {
-    override fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler) {
-        V26_1PacketLoreListener.register(plugin, identifier, listener)
+    override fun register(plugin: Plugin, identifier: NamespacedKey, listener: SurfPaperPacketLoreHandler, priority: Short) {
+        V26_1PacketLoreListener.register(plugin, identifier, listener, priority)
     }
 
-    override fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler) {
-        V26_1PacketLoreListener.register(plugin, listener)
+    override fun register(plugin: Plugin, listener: SurfPaperPacketLoreHandler, priority: Short) {
+        V26_1PacketLoreListener.register(plugin, listener, priority)
     }
 
     override fun unregister(identifier: NamespacedKey) {

--- a/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
+++ b/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
@@ -45,7 +45,8 @@ tasks {
         dependsOn(":surf-api-paper:surf-api-paper-server:shadowJar")
         pluginJars.from(project(":surf-api-paper:surf-api-paper-server").tasks.shadowJar)
 
-        minecraftVersion(findProperty("mcVersion") as String)
+//        minecraftVersion(findProperty("mcVersion") as String)
+minecraftVersion("1.21.11")
 
         downloadPlugins {
             hangar("CommandAPI", libs.versions.commandapi.get())

--- a/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
+++ b/surf-api-paper/surf-api-paper-plugin-test/build.gradle.kts
@@ -45,8 +45,7 @@ tasks {
         dependsOn(":surf-api-paper:surf-api-paper-server:shadowJar")
         pluginJars.from(project(":surf-api-paper:surf-api-paper-server").tasks.shadowJar)
 
-//        minecraftVersion(findProperty("mcVersion") as String)
-minecraftVersion("1.21.11")
+        minecraftVersion(findProperty("mcVersion") as String)
 
         downloadPlugins {
             hangar("CommandAPI", libs.versions.commandapi.get())

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/impl/packet/SurfPaperPacketApiImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/impl/packet/SurfPaperPacketApiImpl.kt
@@ -22,16 +22,18 @@ class SurfPaperPacketApiImpl : SurfPaperPacketApi {
     override fun registerPacketLoreListener(
         plugin: Plugin,
         identifier: NamespacedKey,
-        listener: SurfPaperPacketLoreHandler
+        listener: SurfPaperPacketLoreHandler,
+        priority: Short
     ) {
-        packetLoreRegistry.register(plugin, identifier, listener)
+        packetLoreRegistry.register(plugin, identifier, listener, priority)
     }
 
     override fun registerPacketLoreListenerGlobal(
         plugin: Plugin,
-        listener: SurfPaperPacketLoreHandler
+        listener: SurfPaperPacketLoreHandler,
+        priority: Short
     ) {
-        packetLoreRegistry.register(plugin, listener)
+        packetLoreRegistry.register(plugin, listener, priority)
     }
 
     override fun unregisterPacketLoreListener(plugin: Plugin) {

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -2039,10 +2039,14 @@ public abstract interface class dev/slne/surf/api/paper/nms/listener/packets/ser
 
 public abstract interface class dev/slne/surf/api/paper/packet/SurfPaperPacketApi {
 	public static final field Companion Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi$Companion;
-	public abstract fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public abstract fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;S)V
 	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
-	public abstract fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
+	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public abstract fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;S)V
 	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
+	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
 	public abstract fun unregisterPacketLoreListener (Lorg/bukkit/NamespacedKey;)V
 	public abstract fun unregisterPacketLoreListener (Lorg/bukkit/plugin/Plugin;)V
 }
@@ -2050,16 +2054,24 @@ public abstract interface class dev/slne/surf/api/paper/packet/SurfPaperPacketAp
 public final class dev/slne/surf/api/paper/packet/SurfPaperPacketApi$Companion : dev/slne/surf/api/paper/packet/SurfPaperPacketApi {
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;
 	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;S)V
 	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
+	public fun registerPacketLoreListener (Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
 	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
+	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;S)V
 	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
+	public fun registerPacketLoreListenerGlobal (Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
 	public fun unregisterPacketLoreListener (Lorg/bukkit/NamespacedKey;)V
 	public fun unregisterPacketLoreListener (Lorg/bukkit/plugin/Plugin;)V
 }
 
 public final class dev/slne/surf/api/paper/packet/SurfPaperPacketApi$DefaultImpls {
+	public static fun registerPacketLoreListener (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
 	public static fun registerPacketLoreListener (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
+	public static fun registerPacketLoreListener (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Lorg/bukkit/NamespacedKey;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
+	public static fun registerPacketLoreListenerGlobal (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)V
 	public static fun registerPacketLoreListenerGlobal (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)V
+	public static fun registerPacketLoreListenerGlobal (Ldev/slne/surf/api/paper/packet/SurfPaperPacketApi;Lorg/bukkit/plugin/Plugin;Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;S)V
 }
 
 public abstract interface class dev/slne/surf/api/paper/packet/listener/SurfPaperPacketListenerApi {
@@ -2093,7 +2105,12 @@ public abstract interface annotation class dev/slne/surf/api/paper/packet/listen
 }
 
 public abstract interface class dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler {
+	public fun getPriority ()S
 	public abstract fun handleLore (Ljava/util/List;Lio/papermc/paper/persistence/PersistentDataContainerView;Lorg/bukkit/inventory/ItemStack;)V
+}
+
+public final class dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler$DefaultImpls {
+	public static fun getPriority (Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler;)S
 }
 
 public abstract interface class dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple : dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler {
@@ -2102,7 +2119,17 @@ public abstract interface class dev/slne/surf/api/paper/packet/lore/SurfPaperPac
 }
 
 public final class dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple$DefaultImpls {
+	public static fun getPriority (Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;)S
 	public static fun handleLore (Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandlerSimple;Ljava/util/List;Lio/papermc/paper/persistence/PersistentDataContainerView;Lorg/bukkit/inventory/ItemStack;)V
+}
+
+public final class dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLorePriority {
+	public static final field EARLY S
+	public static final field FIRST S
+	public static final field INSTANCE Ldev/slne/surf/api/paper/packet/lore/SurfPaperPacketLorePriority;
+	public static final field LAST S
+	public static final field LATE S
+	public static final field NORMAL S
 }
 
 public abstract interface class dev/slne/surf/api/paper/pdc/block/BlockPdcProvider {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/SurfPaperPacketApi.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/SurfPaperPacketApi.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.api.paper.packet
 import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLoreHandler
 import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLoreHandlerSimple
+import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLorePriority
 import org.bukkit.NamespacedKey
 import org.bukkit.plugin.Plugin
 
@@ -26,6 +27,31 @@ interface SurfPaperPacketApi {
      * listener lifecycle — all listeners registered under a plugin are automatically cleaned up
      * when [unregisterPacketLoreListener(Plugin)] is called.
      *
+     * Handlers are invoked in ascending order of [priority] — the smaller the value, the earlier
+     * the handler is called. See [SurfPaperPacketLorePriority] for the available predefined
+     * constants. If [priority] is omitted, [SurfPaperPacketLoreHandler.priority] is used.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The listener that modifies the lore of the item stack.
+     * @param priority The execution priority of this listener. Defaults to the listener's own
+     *   [SurfPaperPacketLoreHandler.priority] (which itself defaults to
+     *   [SurfPaperPacketLorePriority.NORMAL]).
+     */
+    fun registerPacketLoreListener(
+        plugin: Plugin,
+        identifier: NamespacedKey,
+        listener: SurfPaperPacketLoreHandler,
+        priority: Short
+    )
+
+    /**
+     * Registers a listener for modifying the lore of a specific item stack identified by [identifier].
+     *
+     * This is the preferred overload. The [plugin] reference is used to properly manage the
+     * listener lifecycle — all listeners registered under a plugin are automatically cleaned up
+     * when [unregisterPacketLoreListener(Plugin)] is called.
+     *
      * @param plugin The plugin registering the listener. Used for lifecycle management.
      * @param identifier A unique key representing the item to listen for.
      * @param listener The listener that modifies the lore of the item stack.
@@ -33,14 +59,38 @@ interface SurfPaperPacketApi {
     fun registerPacketLoreListener(
         plugin: Plugin,
         identifier: NamespacedKey,
-        listener: SurfPaperPacketLoreHandler
-    )
+        listener: SurfPaperPacketLoreHandler,
+    ) {
+        registerPacketLoreListener(plugin, identifier, listener, listener.priority)
+    }
 
     /**
      * Registers a simplified listener for modifying the lore of a specific item stack identified by [identifier].
      *
      * This is the preferred overload. Delegates to
-     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfBukkitPacketLoreHandler)].
+     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfPaperPacketLoreHandler, Short)].
+     * The [plugin] reference is used to properly manage the listener lifecycle.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param identifier A unique key representing the item to listen for.
+     * @param listener The simplified lore listener that focuses solely on modifying the lore list.
+     * @param priority The execution priority of this listener. Defaults to the listener's own
+     *   [SurfPaperPacketLoreHandler.priority].
+     */
+    fun registerPacketLoreListener(
+        plugin: Plugin,
+        identifier: NamespacedKey,
+        listener: SurfPaperPacketLoreHandlerSimple,
+        priority: Short
+    ) {
+        registerPacketLoreListener(plugin, identifier, listener as SurfPaperPacketLoreHandler, priority)
+    }
+
+    /**
+     * Registers a simplified listener for modifying the lore of a specific item stack identified by [identifier].
+     *
+     * This is the preferred overload. Delegates to
+     * [registerPacketLoreListener(Plugin, NamespacedKey, SurfPaperPacketLoreHandler, Short)].
      * The [plugin] reference is used to properly manage the listener lifecycle.
      *
      * @param plugin The plugin registering the listener. Used for lifecycle management.
@@ -50,10 +100,31 @@ interface SurfPaperPacketApi {
     fun registerPacketLoreListener(
         plugin: Plugin,
         identifier: NamespacedKey,
-        listener: SurfPaperPacketLoreHandlerSimple
+        listener: SurfPaperPacketLoreHandlerSimple,
     ) {
-        registerPacketLoreListener(plugin, identifier, listener as SurfPaperPacketLoreHandler)
+        registerPacketLoreListener(plugin, identifier, listener as SurfPaperPacketLoreHandler, listener.priority)
     }
+
+    /**
+     * Registers a lore listener globally to handle lore modifications for all items.
+     *
+     * Unlike the key-based overloads, this listener fires for every item stack regardless of
+     * its identifier. Use this only when you genuinely need to intercept all items, as it has
+     * a broader performance impact.
+     *
+     * Handlers are invoked in ascending order of [priority] across both keyed and global
+     * listeners — the smaller the value, the earlier the handler is called.
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param listener The lore listener to handle lore modifications globally.
+     * @param priority The execution priority of this listener. Defaults to the listener's own
+     *   [SurfPaperPacketLoreHandler.priority].
+     */
+    fun registerPacketLoreListenerGlobal(
+        plugin: Plugin,
+        listener: SurfPaperPacketLoreHandler,
+        priority: Short
+    )
 
     /**
      * Registers a lore listener globally to handle lore modifications for all items.
@@ -67,22 +138,42 @@ interface SurfPaperPacketApi {
      */
     fun registerPacketLoreListenerGlobal(
         plugin: Plugin,
-        listener: SurfPaperPacketLoreHandler
-    )
+        listener: SurfPaperPacketLoreHandler,
+    ) {
+        registerPacketLoreListenerGlobal(plugin, listener, listener.priority)
+    }
 
     /**
      * Registers a simplified lore listener globally for all items.
      *
-     * Delegates to [registerPacketLoreListenerGlobal(Plugin, SurfBukkitPacketLoreHandler)].
+     * Delegates to [registerPacketLoreListenerGlobal(Plugin, SurfPaperPacketLoreHandler, Short)].
+     *
+     * @param plugin The plugin registering the listener. Used for lifecycle management.
+     * @param listener The simplified lore listener that focuses solely on the lore list.
+     * @param priority The execution priority of this listener. Defaults to the listener's own
+     *   [SurfPaperPacketLoreHandler.priority].
+     */
+    fun registerPacketLoreListenerGlobal(
+        plugin: Plugin,
+        listener: SurfPaperPacketLoreHandlerSimple,
+        priority: Short
+    ) {
+        registerPacketLoreListenerGlobal(plugin, listener as SurfPaperPacketLoreHandler, priority)
+    }
+
+    /**
+     * Registers a simplified lore listener globally for all items.
+     *
+     * Delegates to [registerPacketLoreListenerGlobal(Plugin, SurfPaperPacketLoreHandler, Short)].
      *
      * @param plugin The plugin registering the listener. Used for lifecycle management.
      * @param listener The simplified lore listener that focuses solely on the lore list.
      */
     fun registerPacketLoreListenerGlobal(
         plugin: Plugin,
-        listener: SurfPaperPacketLoreHandlerSimple
+        listener: SurfPaperPacketLoreHandlerSimple,
     ) {
-        registerPacketLoreListenerGlobal(plugin, listener as SurfPaperPacketLoreHandler)
+        registerPacketLoreListenerGlobal(plugin, listener, listener.priority)
     }
 
     /**

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLoreHandler.kt
@@ -16,6 +16,19 @@ import org.bukkit.inventory.ItemStack
  */
 fun interface SurfPaperPacketLoreHandler {
     /**
+     * The priority controlling when this handler is invoked relative to others.
+     *
+     * Smaller values run earlier, larger values run later. Defaults to
+     * [SurfPaperPacketLorePriority.NORMAL]. See [SurfPaperPacketLorePriority] for the
+     * available predefined constants.
+     *
+     * Implementations may override this to provide a per-handler default. The priority
+     * passed when registering the handler (if any) takes precedence over this value.
+     */
+    val priority: Short
+        get() = SurfPaperPacketLorePriority.NORMAL
+
+    /**
      * Handles the modification of the lore of an item stack.
      *
      * @param loreToDisplay A mutable list of lore components representing the text displayed

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLorePriority.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/packet/lore/SurfPaperPacketLorePriority.kt
@@ -1,0 +1,59 @@
+package dev.slne.surf.api.paper.packet.lore
+
+import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLorePriority.FIRST
+import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLorePriority.LAST
+import dev.slne.surf.api.paper.packet.lore.SurfPaperPacketLorePriority.NORMAL
+
+
+/**
+ * Predefined priority constants for [SurfPaperPacketLoreHandler]s.
+ *
+ * Handlers are invoked in **ascending** order of their priority — the smaller the value,
+ * the earlier the handler is called; the larger the value, the later it is called.
+ *
+ * This means a handler registered with [FIRST] runs before one registered with [LAST],
+ * giving the latter the chance to override or post-process whatever earlier handlers wrote
+ * to the lore list.
+ *
+ * Priorities are exposed as [Short] to keep memory overhead low while still leaving plenty
+ * of room between the predefined values for fine-grained custom ordering.
+ *
+ * Example:
+ * ```
+ * SurfPaperPacketApi.registerPacketLoreListener(
+ *     plugin,
+ *     key,
+ *     handler,
+ *     priority = SurfPaperPacketLorePriority.LATE,
+ * )
+ * ```
+ */
+object SurfPaperPacketLorePriority {
+    /**
+     * Runs first, before every other handler. Use this when you want to *prepare* lore
+     * that subsequent handlers will inspect or extend.
+     */
+    const val FIRST: Short = Short.MIN_VALUE
+
+    /**
+     * Runs early, but allows handlers using [FIRST] to go before this one.
+     */
+    const val EARLY: Short = -16384
+
+    /**
+     * The default priority used by handlers that don't override it.
+     */
+    const val NORMAL: Short = 0
+
+    /**
+     * Runs late, after [NORMAL] but before [LAST].
+     */
+    const val LATE: Short = 16384
+
+    /**
+     * Runs last, after every other handler. Use this when you want to have the final say
+     * on the lore list — e.g. for stripping or post-processing.
+     */
+    const val LAST: Short = Short.MAX_VALUE
+}
+


### PR DESCRIPTION
This pull request introduces a priority system for packet lore handlers, allowing handlers to be registered with a priority value that determines their execution order. It updates the relevant APIs, registry, and listener implementations to support handler prioritization and ensures that handlers are always invoked in the correct order. Additionally, it includes a minor build script update and a version bump.

### Handler Prioritization

* Added a `priority: Short` parameter to all `register` methods in `PacketLoreRegistry` and its implementations, so handlers can be registered with a specific priority. Lower values are executed first. [[1]](diffhunk://#diff-6955c8bc81564fe0784f0fd0164125fbf2dc93d9858f8fd01fd5e29a705684aeL14-R15) [[2]](diffhunk://#diff-c2160af86fefb2b40959e21425e70ae9eacc43955ac68bf161926eea3093ddf0L9-R14) [[3]](diffhunk://#diff-c842bd15b648ef391a353c6262bbf9d9602205317aaaa99ae7ccdf4ebfc405aeL10-R15) [[4]](diffhunk://#diff-9bdce672564dae25ebf882d18f045d4dd1fa4a82ab33caa82f5b8fa0710edc67L25-R36)
* Introduced a `PriorityHandler` data class and a comparator to both `V1_21_11PacketLoreListener` and `V26_1PacketLoreListener`, and updated all internal data structures and registration logic to use it. Handler invocation now sorts and executes by priority across both keyed and global handlers. [[1]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2R35-R53) [[2]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2L330-R354) [[3]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2L386-R411) [[4]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2L406-R425) [[5]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2L415-R460) [[6]](diffhunk://#diff-b1862b5c8c473615167a6584b89ae5061f83ba52720b17491d125c4de99acda2L484-R521) [[7]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400R36-R54) [[8]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400L339-R362) [[9]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400L395-R419) [[10]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400L415-R433) [[11]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400L424-R468) [[12]](diffhunk://#diff-a985918bc8aeda1fb74d0fd6c142bd9e7a4e38981b593792c56c4d9544cc4400L493-R529)

### API and Implementation Updates

* Updated `SurfPaperPacketApiImpl` to require and correctly forward the new `priority` parameter in its registration methods.

### Build and Versioning

* Bumped project version to `3.4.0` in `gradle.properties`.