### PR TITLE
Feat/creative search item order comparator

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.4.0
+version=3.5.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
@@ -95,6 +95,7 @@ class V1_21_11NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
 
     override fun initialize() {
         V1_21_11Reflection.initialize()
+        V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.init()
     }
 
     override fun shutdown() {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsItemBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsItemBridgeImpl.kt
@@ -2,10 +2,26 @@ package dev.slne.surf.api.paper.server.nms.v1_21_11.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsItemBridge
+import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.exactIndex
+import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.indexOf
+import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.itemTypeIndex
+import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.materialIndex
+import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.V1_21_11SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.mayHaveComponentVariant
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.nms
+import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toIdentifier
+import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.unwrap
 import dev.slne.surf.api.paper.server.nms.v1_21_11.reflection.V1_21_11Reflection
+import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap
 import net.minecraft.core.component.DataComponentMap
 import net.minecraft.core.component.DataComponents
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.world.item.CreativeModeTabs
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.ItemStackLinkedSet
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 
 @NmsUseWithCaution
@@ -21,5 +37,158 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
 
 
         V1_21_11Reflection.ITEM_PROXY.setComponents(nmsItem, updatedComponents)
+    }
+
+    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack> {
+        return CreativeOrderComparator
+    }
+
+    /**
+     * A [Comparator] that orders [ItemStack]s according to the order in which they appear in the
+     * creative mode search tab.
+     *
+     * Items with component-based variants (e.g. potions, enchanted books) are resolved using an
+     * exact NMS-level lookup so that each variant is placed at its dedicated creative-tab position.
+     * All other items fall back to a per-[Material] index derived from the first occurrence of the
+     * corresponding [Item] type in the search tab.
+     *
+     * Items that are not present in the creative search tab at all receive an index of
+     * [Int.MAX_VALUE] and are therefore sorted to the end.
+     */
+    object CreativeOrderComparator : Comparator<ItemStack> {
+        /**
+         * A map from NMS [net.minecraft.world.item.ItemStack] to its position in the creative
+         * search tab, keyed by both item type **and** data components so that component-variant
+         * items (e.g. a specific potion effect) are resolved exactly.
+         *
+         * Populated lazily on first access from [CreativeModeTabs.searchTab].
+         */
+        private val exactIndex by lazy {
+            val ordered = CreativeModeTabs.searchTab().displayItems
+            val map = Object2IntOpenCustomHashMap(ordered.size, ItemStackLinkedSet.TYPE_AND_TAG)
+            map.defaultReturnValue(Int.MAX_VALUE)
+
+            var i = 0
+            for (item in ordered) map.put(item, i++)
+            map
+        }
+
+        /**
+         * A map from NMS [Item] to the position of its **first** occurrence in the creative search
+         * tab.
+         *
+         * Used as a fast fallback when an exact component-level match is not required or not found.
+         * The index stored here corresponds to the earliest slot at which any stack of that item
+         * type appears in [CreativeModeTabs.searchTab].
+         *
+         * Populated lazily on first access.
+         */
+        private val itemTypeIndex: Reference2IntOpenHashMap<Item> by lazy {
+            val ordered = CreativeModeTabs.searchTab().displayItems
+            val map = Reference2IntOpenHashMap<Item>(ordered.size)
+            map.defaultReturnValue(Int.MAX_VALUE)
+
+            for ((i, stack) in ordered.withIndex()) {
+                val item = stack.item
+                map.putIfAbsent(item, i)
+            }
+
+            map
+        }
+
+        /**
+         * A map from Bukkit [Material] to the creative-tab index of that material, derived from
+         * [itemTypeIndex].
+         *
+         * Only materials for which [Material.isItem] is `true` are included. The index is resolved
+         * by converting the material's namespaced key to a NMS `ResourceLocation`
+         * and looking up the corresponding [Item] in [BuiltInRegistries.ITEM].
+         *
+         * Populated lazily on first access.
+         */
+        private val materialIndex: Object2IntOpenHashMap<Material> by lazy {
+            val out = Object2IntOpenHashMap<Material>(Material.entries.size)
+            out.defaultReturnValue(Int.MAX_VALUE)
+
+            for (mat in Material.entries) {
+                if (!mat.isItem) continue
+
+                val key = mat.key.toIdentifier()
+                val item = BuiltInRegistries.ITEM.getValue(key)
+
+                out.put(mat, itemTypeIndex.getInt(item))
+            }
+
+            out
+        }
+
+        /**
+         * Compares two [ItemStack]s by their position in the creative search tab.
+         *
+         * @param a the first item stack to compare.
+         * @param b the second item stack to compare.
+         * @return a negative integer if [a] appears before [b] in the creative search tab,
+         *   zero if their positions are equal, or a positive integer if [a] appears after [b].
+         */
+        override fun compare(a: ItemStack, b: ItemStack): Int {
+            val aIndex = indexOf(a)
+            val bIndex = indexOf(b)
+
+            return aIndex.compareTo(bIndex)
+        }
+
+        /**
+         * Returns the creative search tab index for the given [stack].
+         *
+         * If the stack's [Material] may have component-specific variants (see
+         * [mayHaveComponentVariant]), an exact NMS-level lookup against [exactIndex] is attempted
+         * first. If no exact match is found the result falls back to the material-level index from
+         * [materialIndex].
+         *
+         * @param stack the item stack whose index should be determined.
+         * @return the zero-based position in the creative search tab, or [Int.MAX_VALUE] if the
+         *   stack is not present in the tab.
+         */
+        private fun indexOf(stack: ItemStack): Int {
+            val type = stack.type
+            val byMaterial = materialIndex.getInt(type)
+
+            if (mayHaveComponentVariant(type)) {
+                val nms = stack.unwrap()
+                val exact = exactIndex.getInt(nms)
+                if (exact != Int.MAX_VALUE) return exact
+            }
+
+            return byMaterial
+        }
+
+        /**
+         * Returns `true` if [material] can have component-based variants that each receive a
+         * distinct position in the creative search tab.
+         *
+         * Items that return `true` here are subject to an exact NMS-level comparison in
+         * [indexOf] so that, for example, individual potion effects or enchantment combinations
+         * are ordered correctly rather than being grouped together at the material's generic
+         * position.
+         *
+         * @param material the material to check.
+         * @return `true` if the material may have component variants, `false` otherwise.
+         */
+        private fun mayHaveComponentVariant(material: Material) = when (material) {
+            Material.POTION,
+            Material.SPLASH_POTION,
+            Material.LINGERING_POTION,
+            Material.TIPPED_ARROW,
+            Material.ENCHANTED_BOOK,
+            Material.FIREWORK_ROCKET,
+            Material.PAINTING,
+            Material.SUSPICIOUS_STEW,
+            Material.OMINOUS_BOTTLE,
+            Material.LIGHT,
+            Material.TEST_BLOCK,
+            Material.GOAT_HORN -> true
+
+            else -> false
+        }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsItemBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsItemBridgeImpl.kt
@@ -17,10 +17,14 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap
 import net.minecraft.core.component.DataComponentMap
 import net.minecraft.core.component.DataComponents
 import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.flag.FeatureFlags
+import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStackLinkedSet
 import org.bukkit.Material
+import org.bukkit.Registry
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 
@@ -39,7 +43,7 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
         V1_21_11Reflection.ITEM_PROXY.setComponents(nmsItem, updatedComponents)
     }
 
-    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack> {
+    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack?> {
         return CreativeOrderComparator
     }
 
@@ -55,7 +59,7 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
      * Items that are not present in the creative search tab at all receive an index of
      * [Int.MAX_VALUE] and are therefore sorted to the end.
      */
-    object CreativeOrderComparator : Comparator<ItemStack> {
+    object CreativeOrderComparator : Comparator<ItemStack?> {
         /**
          * A map from NMS [net.minecraft.world.item.ItemStack] to its position in the creative
          * search tab, keyed by both item type **and** data components so that component-variant
@@ -63,15 +67,7 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access from [CreativeModeTabs.searchTab].
          */
-        private val exactIndex by lazy {
-            val ordered = CreativeModeTabs.searchTab().displayItems
-            val map = Object2IntOpenCustomHashMap(ordered.size, ItemStackLinkedSet.TYPE_AND_TAG)
-            map.defaultReturnValue(Int.MAX_VALUE)
-
-            var i = 0
-            for (item in ordered) map.put(item, i++)
-            map
-        }
+        private lateinit var exactIndex: Object2IntOpenCustomHashMap<net.minecraft.world.item.ItemStack>
 
         /**
          * A map from NMS [Item] to the position of its **first** occurrence in the creative search
@@ -83,18 +79,7 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access.
          */
-        private val itemTypeIndex: Reference2IntOpenHashMap<Item> by lazy {
-            val ordered = CreativeModeTabs.searchTab().displayItems
-            val map = Reference2IntOpenHashMap<Item>(ordered.size)
-            map.defaultReturnValue(Int.MAX_VALUE)
-
-            for ((i, stack) in ordered.withIndex()) {
-                val item = stack.item
-                map.putIfAbsent(item, i)
-            }
-
-            map
-        }
+        private lateinit var itemTypeIndex: Reference2IntOpenHashMap<Item>
 
         /**
          * A map from Bukkit [Material] to the creative-tab index of that material, derived from
@@ -106,20 +91,53 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access.
          */
-        private val materialIndex: Object2IntOpenHashMap<Material> by lazy {
-            val out = Object2IntOpenHashMap<Material>(Material.entries.size)
-            out.defaultReturnValue(Int.MAX_VALUE)
+        private lateinit var materialIndex: Object2IntOpenHashMap<Material>
 
-            for (mat in Material.entries) {
-                if (!mat.isItem) continue
 
-                val key = mat.key.toIdentifier()
-                val item = BuiltInRegistries.ITEM.getValue(key)
+        fun init() {
+            val params = CreativeModeTab.ItemDisplayParameters(
+                FeatureFlags.DEFAULT_FLAGS,
+                true,
+                MinecraftServer.getServer().registryAccess()
+            )
 
-                out.put(mat, itemTypeIndex.getInt(item))
+            for (tab in BuiltInRegistries.CREATIVE_MODE_TAB) {
+                if (tab.type != CreativeModeTab.Type.CATEGORY) continue
+                tab.buildContents(params)
+            }
+            for (tab in BuiltInRegistries.CREATIVE_MODE_TAB) {
+                if (tab.type == CreativeModeTab.Type.CATEGORY) continue
+                tab.buildContents(params)
             }
 
-            out
+            val orderedItems = CreativeModeTabs.searchTab().displayItems
+
+            this.exactIndex = Object2IntOpenCustomHashMap(orderedItems.size, ItemStackLinkedSet.TYPE_AND_TAG).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+                var i = 0
+                for (item in orderedItems) put(item, i++)
+            }
+
+            this.itemTypeIndex = Reference2IntOpenHashMap<Item>(Material.entries.size).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+
+                for ((i, stack) in orderedItems.withIndex()) {
+                    val item = stack.item
+                    putIfAbsent(item, i)
+                }
+            }
+
+            this.materialIndex = Object2IntOpenHashMap<Material>(Registry.ITEM.size()).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+
+                for (itemType in Registry.ITEM) {
+                    val key = itemType.key.toIdentifier()
+                    val item = BuiltInRegistries.ITEM.getValue(key)
+
+                    @Suppress("DEPRECATION")
+                    put(itemType.asMaterial(), itemTypeIndex.getInt(item))
+                }
+            }
         }
 
         /**
@@ -130,7 +148,7 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          * @return a negative integer if [a] appears before [b] in the creative search tab,
          *   zero if their positions are equal, or a positive integer if [a] appears after [b].
          */
-        override fun compare(a: ItemStack, b: ItemStack): Int {
+        override fun compare(a: ItemStack?, b: ItemStack?): Int {
             val aIndex = indexOf(a)
             val bIndex = indexOf(b)
 
@@ -149,7 +167,9 @@ class V1_21_11SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          * @return the zero-based position in the creative search tab, or [Int.MAX_VALUE] if the
          *   stack is not present in the tab.
          */
-        private fun indexOf(stack: ItemStack): Int {
+        private fun indexOf(stack: ItemStack?): Int {
+            if (stack == null) return Int.MAX_VALUE
+
             val type = stack.type
             val byMaterial = materialIndex.getInt(type)
 

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/extensions/nms-extensions.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/extensions/nms-extensions.kt
@@ -14,6 +14,7 @@ import net.minecraft.advancements.AdvancementType
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Holder
 import net.minecraft.network.chat.Component
+import net.minecraft.resources.Identifier
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.Display
@@ -25,6 +26,7 @@ import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.SignText
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import org.bukkit.Server
 import org.bukkit.World
 import org.bukkit.block.BlockState
@@ -76,6 +78,7 @@ fun Billboard.toNms(): Display.BillboardConstraints =
     Display.BillboardConstraints.valueOf(this.name)
 
 fun ItemStack.toNms(): NmsItemStack = CraftItemStack.asNMSCopy(this)
+fun ItemStack.unwrap(): NmsItemStack = CraftItemStack.unwrap(this)
 fun ItemDisplayTransform.toNms(): ItemDisplayContext = ItemDisplayContext.BY_ID.apply(this.ordinal)
 fun NmsItemStack.toBukkit(): ItemStack = CraftItemStack.asBukkitCopy(this)
 val ItemType.nms: Item get() = CraftItemType.bukkitToMinecraftNew(this)
@@ -148,3 +151,5 @@ fun AdvancementDisplay.Frame.toNms() = when (this) {
     GOAL -> AdvancementType.GOAL
     TASK -> AdvancementType.TASK
 }
+
+fun NamespacedKey.toIdentifier() = Identifier.fromNamespaceAndPath(namespace, key)

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
@@ -95,6 +95,7 @@ class V26_1NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
 
     override fun initialize() {
         V26_1Reflection.initialize()
+        V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.init()
     }
 
     override fun shutdown() {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsItemBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsItemBridgeImpl.kt
@@ -2,9 +2,25 @@ package dev.slne.surf.api.paper.server.nms.v26_1.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsItemBridge
+import dev.slne.surf.api.paper.server.nms.v26_1.bridges.V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.exactIndex
+import dev.slne.surf.api.paper.server.nms.v26_1.bridges.V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.indexOf
+import dev.slne.surf.api.paper.server.nms.v26_1.bridges.V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.itemTypeIndex
+import dev.slne.surf.api.paper.server.nms.v26_1.bridges.V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.materialIndex
+import dev.slne.surf.api.paper.server.nms.v26_1.bridges.V26_1SurfPaperNmsItemBridgeImpl.CreativeOrderComparator.mayHaveComponentVariant
 import dev.slne.surf.api.paper.server.nms.v26_1.extensions.nms
+import dev.slne.surf.api.paper.server.nms.v26_1.extensions.toIdentifier
+import dev.slne.surf.api.paper.server.nms.v26_1.extensions.unwrap
+import it.unimi.dsi.fastutil.objects.Object2IntOpenCustomHashMap
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap
+import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap
 import net.minecraft.core.component.DataComponentMap
 import net.minecraft.core.component.DataComponents
+import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.world.item.CreativeModeTabs
+import net.minecraft.world.item.Item
+import net.minecraft.world.item.ItemStackLinkedSet
+import org.bukkit.Material
+import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 
 @NmsUseWithCaution
@@ -21,5 +37,158 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
 
         @Suppress("DEPRECATION")
         nmsItem.builtInRegistryHolder().bindComponents(updatedComponents)
+    }
+
+    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack> {
+        return CreativeOrderComparator
+    }
+
+    /**
+     * A [Comparator] that orders [ItemStack]s according to the order in which they appear in the
+     * creative mode search tab.
+     *
+     * Items with component-based variants (e.g. potions, enchanted books) are resolved using an
+     * exact NMS-level lookup so that each variant is placed at its dedicated creative-tab position.
+     * All other items fall back to a per-[Material] index derived from the first occurrence of the
+     * corresponding [Item] type in the search tab.
+     *
+     * Items that are not present in the creative search tab at all receive an index of
+     * [Int.MAX_VALUE] and are therefore sorted to the end.
+     */
+    object CreativeOrderComparator : Comparator<ItemStack> {
+        /**
+         * A map from NMS [net.minecraft.world.item.ItemStack] to its position in the creative
+         * search tab, keyed by both item type **and** data components so that component-variant
+         * items (e.g. a specific potion effect) are resolved exactly.
+         *
+         * Populated lazily on first access from [CreativeModeTabs.searchTab].
+         */
+        private val exactIndex by lazy {
+            val ordered = CreativeModeTabs.searchTab().displayItems
+            val map = Object2IntOpenCustomHashMap(ordered.size, ItemStackLinkedSet.TYPE_AND_TAG)
+            map.defaultReturnValue(Int.MAX_VALUE)
+
+            var i = 0
+            for (item in ordered) map.put(item, i++)
+            map
+        }
+
+        /**
+         * A map from NMS [Item] to the position of its **first** occurrence in the creative search
+         * tab.
+         *
+         * Used as a fast fallback when an exact component-level match is not required or not found.
+         * The index stored here corresponds to the earliest slot at which any stack of that item
+         * type appears in [CreativeModeTabs.searchTab].
+         *
+         * Populated lazily on first access.
+         */
+        private val itemTypeIndex: Reference2IntOpenHashMap<Item> by lazy {
+            val ordered = CreativeModeTabs.searchTab().displayItems
+            val map = Reference2IntOpenHashMap<Item>(ordered.size)
+            map.defaultReturnValue(Int.MAX_VALUE)
+
+            for ((i, stack) in ordered.withIndex()) {
+                val item = stack.item
+                map.putIfAbsent(item, i)
+            }
+
+            map
+        }
+
+        /**
+         * A map from Bukkit [Material] to the creative-tab index of that material, derived from
+         * [itemTypeIndex].
+         *
+         * Only materials for which [Material.isItem] is `true` are included. The index is resolved
+         * by converting the material's namespaced key to a NMS `ResourceLocation`
+         * and looking up the corresponding [Item] in [BuiltInRegistries.ITEM].
+         *
+         * Populated lazily on first access.
+         */
+        private val materialIndex: Object2IntOpenHashMap<Material> by lazy {
+            val out = Object2IntOpenHashMap<Material>(Material.entries.size)
+            out.defaultReturnValue(Int.MAX_VALUE)
+
+            for (mat in Material.entries) {
+                if (!mat.isItem) continue
+
+                val key = mat.key.toIdentifier()
+                val item = BuiltInRegistries.ITEM.getValue(key)
+
+                out.put(mat, itemTypeIndex.getInt(item))
+            }
+
+            out
+        }
+
+        /**
+         * Compares two [ItemStack]s by their position in the creative search tab.
+         *
+         * @param a the first item stack to compare.
+         * @param b the second item stack to compare.
+         * @return a negative integer if [a] appears before [b] in the creative search tab,
+         *   zero if their positions are equal, or a positive integer if [a] appears after [b].
+         */
+        override fun compare(a: ItemStack, b: ItemStack): Int {
+            val aIndex = indexOf(a)
+            val bIndex = indexOf(b)
+
+            return aIndex.compareTo(bIndex)
+        }
+
+        /**
+         * Returns the creative search tab index for the given [stack].
+         *
+         * If the stack's [Material] may have component-specific variants (see
+         * [mayHaveComponentVariant]), an exact NMS-level lookup against [exactIndex] is attempted
+         * first. If no exact match is found the result falls back to the material-level index from
+         * [materialIndex].
+         *
+         * @param stack the item stack whose index should be determined.
+         * @return the zero-based position in the creative search tab, or [Int.MAX_VALUE] if the
+         *   stack is not present in the tab.
+         */
+        private fun indexOf(stack: ItemStack): Int {
+            val type = stack.type
+            val byMaterial = materialIndex.getInt(type)
+
+            if (mayHaveComponentVariant(type)) {
+                val nms = stack.unwrap()
+                val exact = exactIndex.getInt(nms)
+                if (exact != Int.MAX_VALUE) return exact
+            }
+
+            return byMaterial
+        }
+
+        /**
+         * Returns `true` if [material] can have component-based variants that each receive a
+         * distinct position in the creative search tab.
+         *
+         * Items that return `true` here are subject to an exact NMS-level comparison in
+         * [indexOf] so that, for example, individual potion effects or enchantment combinations
+         * are ordered correctly rather than being grouped together at the material's generic
+         * position.
+         *
+         * @param material the material to check.
+         * @return `true` if the material may have component variants, `false` otherwise.
+         */
+        private fun mayHaveComponentVariant(material: Material) = when (material) {
+            Material.POTION,
+            Material.SPLASH_POTION,
+            Material.LINGERING_POTION,
+            Material.TIPPED_ARROW,
+            Material.ENCHANTED_BOOK,
+            Material.FIREWORK_ROCKET,
+            Material.PAINTING,
+            Material.SUSPICIOUS_STEW,
+            Material.OMINOUS_BOTTLE,
+            Material.LIGHT,
+            Material.TEST_BLOCK,
+            Material.GOAT_HORN -> true
+
+            else -> false
+        }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsItemBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsItemBridgeImpl.kt
@@ -16,10 +16,14 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap
 import net.minecraft.core.component.DataComponentMap
 import net.minecraft.core.component.DataComponents
 import net.minecraft.core.registries.BuiltInRegistries
+import net.minecraft.server.MinecraftServer
+import net.minecraft.world.flag.FeatureFlags
+import net.minecraft.world.item.CreativeModeTab
 import net.minecraft.world.item.CreativeModeTabs
 import net.minecraft.world.item.Item
 import net.minecraft.world.item.ItemStackLinkedSet
 import org.bukkit.Material
+import org.bukkit.Registry
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 
@@ -39,7 +43,7 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
         nmsItem.builtInRegistryHolder().bindComponents(updatedComponents)
     }
 
-    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack> {
+    override fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack?> {
         return CreativeOrderComparator
     }
 
@@ -55,7 +59,7 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
      * Items that are not present in the creative search tab at all receive an index of
      * [Int.MAX_VALUE] and are therefore sorted to the end.
      */
-    object CreativeOrderComparator : Comparator<ItemStack> {
+    object CreativeOrderComparator : Comparator<ItemStack?> {
         /**
          * A map from NMS [net.minecraft.world.item.ItemStack] to its position in the creative
          * search tab, keyed by both item type **and** data components so that component-variant
@@ -63,15 +67,7 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access from [CreativeModeTabs.searchTab].
          */
-        private val exactIndex by lazy {
-            val ordered = CreativeModeTabs.searchTab().displayItems
-            val map = Object2IntOpenCustomHashMap(ordered.size, ItemStackLinkedSet.TYPE_AND_TAG)
-            map.defaultReturnValue(Int.MAX_VALUE)
-
-            var i = 0
-            for (item in ordered) map.put(item, i++)
-            map
-        }
+        private lateinit var exactIndex: Object2IntOpenCustomHashMap<net.minecraft.world.item.ItemStack>
 
         /**
          * A map from NMS [Item] to the position of its **first** occurrence in the creative search
@@ -83,18 +79,7 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access.
          */
-        private val itemTypeIndex: Reference2IntOpenHashMap<Item> by lazy {
-            val ordered = CreativeModeTabs.searchTab().displayItems
-            val map = Reference2IntOpenHashMap<Item>(ordered.size)
-            map.defaultReturnValue(Int.MAX_VALUE)
-
-            for ((i, stack) in ordered.withIndex()) {
-                val item = stack.item
-                map.putIfAbsent(item, i)
-            }
-
-            map
-        }
+        private lateinit var itemTypeIndex: Reference2IntOpenHashMap<Item>
 
         /**
          * A map from Bukkit [Material] to the creative-tab index of that material, derived from
@@ -106,20 +91,53 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          *
          * Populated lazily on first access.
          */
-        private val materialIndex: Object2IntOpenHashMap<Material> by lazy {
-            val out = Object2IntOpenHashMap<Material>(Material.entries.size)
-            out.defaultReturnValue(Int.MAX_VALUE)
+        private lateinit var materialIndex: Object2IntOpenHashMap<Material>
 
-            for (mat in Material.entries) {
-                if (!mat.isItem) continue
 
-                val key = mat.key.toIdentifier()
-                val item = BuiltInRegistries.ITEM.getValue(key)
+        fun init() {
+            val params = CreativeModeTab.ItemDisplayParameters(
+                FeatureFlags.DEFAULT_FLAGS,
+                true,
+                MinecraftServer.getServer().registryAccess()
+            )
 
-                out.put(mat, itemTypeIndex.getInt(item))
+            for (tab in BuiltInRegistries.CREATIVE_MODE_TAB) {
+                if (tab.type != CreativeModeTab.Type.CATEGORY) continue
+                tab.buildContents(params)
+            }
+            for (tab in BuiltInRegistries.CREATIVE_MODE_TAB) {
+                if (tab.type == CreativeModeTab.Type.CATEGORY) continue
+                tab.buildContents(params)
             }
 
-            out
+            val orderedItems = CreativeModeTabs.searchTab().displayItems
+
+            this.exactIndex = Object2IntOpenCustomHashMap(orderedItems.size, ItemStackLinkedSet.TYPE_AND_TAG).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+                var i = 0
+                for (item in orderedItems) put(item, i++)
+            }
+
+            this.itemTypeIndex = Reference2IntOpenHashMap<Item>(Material.entries.size).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+
+                for ((i, stack) in orderedItems.withIndex()) {
+                    val item = stack.item
+                    putIfAbsent(item, i)
+                }
+            }
+
+            this.materialIndex = Object2IntOpenHashMap<Material>(Registry.ITEM.size()).apply {
+                defaultReturnValue(Int.MAX_VALUE)
+
+                for (itemType in Registry.ITEM) {
+                    val key = itemType.key.toIdentifier()
+                    val item = BuiltInRegistries.ITEM.getValue(key)
+
+                    @Suppress("DEPRECATION")
+                    put(itemType.asMaterial(), itemTypeIndex.getInt(item))
+                }
+            }
         }
 
         /**
@@ -130,7 +148,7 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          * @return a negative integer if [a] appears before [b] in the creative search tab,
          *   zero if their positions are equal, or a positive integer if [a] appears after [b].
          */
-        override fun compare(a: ItemStack, b: ItemStack): Int {
+        override fun compare(a: ItemStack?, b: ItemStack?): Int {
             val aIndex = indexOf(a)
             val bIndex = indexOf(b)
 
@@ -149,7 +167,9 @@ class V26_1SurfPaperNmsItemBridgeImpl : SurfPaperNmsItemBridge {
          * @return the zero-based position in the creative search tab, or [Int.MAX_VALUE] if the
          *   stack is not present in the tab.
          */
-        private fun indexOf(stack: ItemStack): Int {
+        private fun indexOf(stack: ItemStack?): Int {
+            if (stack == null) return Int.MAX_VALUE
+
             val type = stack.type
             val byMaterial = materialIndex.getInt(type)
 

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/extensions/nms-extensions.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/extensions/nms-extensions.kt
@@ -14,6 +14,7 @@ import net.minecraft.advancements.AdvancementType
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Holder
 import net.minecraft.network.chat.Component
+import net.minecraft.resources.Identifier
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.Display
@@ -25,6 +26,7 @@ import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.entity.SignText
 import net.minecraft.world.phys.Vec3
 import org.bukkit.Material
+import org.bukkit.NamespacedKey
 import org.bukkit.Server
 import org.bukkit.World
 import org.bukkit.block.BlockState
@@ -76,6 +78,7 @@ fun Billboard.toNms(): Display.BillboardConstraints =
     Display.BillboardConstraints.valueOf(this.name)
 
 fun ItemStack.toNms(): NmsItemStack = CraftItemStack.asNMSCopy(this)
+fun ItemStack.unwrap(): NmsItemStack = CraftItemStack.unwrap(this)
 fun ItemDisplayTransform.toNms(): ItemDisplayContext = ItemDisplayContext.BY_ID.apply(this.ordinal)
 fun NmsItemStack.toBukkit(): ItemStack = CraftItemStack.asBukkitCopy(this)
 val ItemType.nms: Item get() = CraftItemType.bukkitToMinecraftNew(this)
@@ -148,3 +151,5 @@ fun AdvancementDisplay.Frame.toNms() = when (this) {
     GOAL -> AdvancementType.GOAL
     TASK -> AdvancementType.TASK
 }
+
+fun NamespacedKey.toIdentifier() = Identifier.fromNamespaceAndPath(namespace, key)

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
@@ -28,7 +28,8 @@ public class SurfApiTestCommand extends CommandAPICommand {
                 new SuspendCommandExecutionTest("suspendCommandExecution"),
                 new SummonCommandTest("summoncommand"),
                 new SurfEventHandlerTest("eventhandler"),
-                new ShowItemCommand("showitem")
+                new ShowItemCommand("showitem"),
+                new SortInvCommand("sortInv")
         );
     }
 }

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SortInvCommand.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SortInvCommand.kt
@@ -1,0 +1,18 @@
+package dev.slne.surf.surfapi.bukkit.test.command.subcommands
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.playerExecutor
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsItemBridge
+
+@OptIn(NmsUseWithCaution::class)
+class SortInvCommand(name: String) : CommandAPICommand(name) {
+
+    init {
+        playerExecutor { player, _ ->
+            val inv = player.inventory
+            val sorted = inv.contents.apply { sortWith(SurfPaperNmsItemBridge.getCreativeSearchItemOrderComparator()) }
+            inv.contents = sorted
+        }
+    }
+}

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1655,10 +1655,12 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsGlowingBridge
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge {
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge$Companion;
+	public abstract fun getCreativeSearchItemOrderComparator ()Ljava/util/Comparator;
 	public abstract fun setDefaultMaxStackSize (Lorg/bukkit/inventory/ItemType;I)V
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge {
+	public fun getCreativeSearchItemOrderComparator ()Ljava/util/Comparator;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge;
 	public fun setDefaultMaxStackSize (Lorg/bukkit/inventory/ItemType;I)V
 }

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge.kt
@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Range
 interface SurfPaperNmsItemBridge {
     fun setDefaultMaxStackSize(item: ItemType, maxStackSize: @Range(from = 1, to = 100) Int)
 
-    fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack>
+    fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack?>
 
     companion object : SurfPaperNmsItemBridge by bridge {
         val INSTANCE get() = bridge

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge.kt
@@ -2,12 +2,15 @@ package dev.slne.surf.api.paper.nms.bridges
 
 import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 import org.jetbrains.annotations.Range
 
 @NmsUseWithCaution
 interface SurfPaperNmsItemBridge {
     fun setDefaultMaxStackSize(item: ItemType, maxStackSize: @Range(from = 1, to = 100) Int)
+
+    fun getCreativeSearchItemOrderComparator(): Comparator<ItemStack>
 
     companion object : SurfPaperNmsItemBridge by bridge {
         val INSTANCE get() = bridge


### PR DESCRIPTION
This pull request introduces a new comparator for creative tab item ordering in both the 1.21.11 and 26.1 Minecraft NMS bridges, along with supporting utility extensions and a version bump. The main goal is to provide a reliable way to sort `ItemStack`s in the same order as they appear in the creative mode search tab, including proper handling of items with component-based variants (like potions or enchanted books).

The most important changes are:

**Creative Tab Item Ordering (Core Logic):**
* Added `CreativeOrderComparator` object to both `V1_21_11SurfPaperNmsItemBridgeImpl` and `V26_1SurfPaperNmsItemBridgeImpl`, implementing a comparator that sorts `ItemStack`s according to their position in the creative mode search tab, with special handling for items with component-based variants. [[1]](diffhunk://#diff-9f953cfed6d4e3bc809afedba828dc574af6acba8644aad36616dfae26610762R45-R213) [[2]](diffhunk://#diff-8fd333c39126dd3b77ceb08c45d7b46a842750321a6711be0da6121c61e03a86R45-R213)
* Exposed this comparator via the new `getCreativeSearchItemOrderComparator()` method in both NMS bridge implementations. [[1]](diffhunk://#diff-9f953cfed6d4e3bc809afedba828dc574af6acba8644aad36616dfae26610762R45-R213) [[2]](diffhunk://#diff-8fd333c39126dd3b77ceb08c45d7b46a842750321a6711be0da6121c61e03a86R45-R213)
* The comparator is initialized during plugin startup by calling its `init()` method in both NMS provider `initialize()` hooks. [[1]](diffhunk://#diff-fe177e1a1fc210d3bf975fd1b3b82967d4c0f149d60499099fa2f13f2c8901a4R98) [[2]](diffhunk://#diff-c1ddd733a1342314c3b642a7ae444a7bda3352d88e369cce9b29f37cd8dc0510R98)

**Utility Extensions and Imports:**
* Added extension functions `ItemStack.unwrap()` and `NamespacedKey.toIdentifier()` in both NMS versions to support NMS-level lookups and registry access. [[1]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR81) [[2]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR154-R155)
* Updated imports in extension files to support new logic. [[1]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR17) [[2]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR29) [[3]](diffhunk://#diff-eaa56ec46ddc67933569ac732dafa0d5074fc26f2c3fb615b32d6a298f047a0bR17) [[4]](diffhunk://#diff-eaa56ec46ddc67933569ac732dafa0d5074fc26f2c3fb615b32d6a298f047a0bR29)

**Versioning:**
* Bumped project version to `3.5.0` in `gradle.properties`.