### PR TITLE
Add support for signed chat messages and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.6.0
+version=3.7.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -4,8 +4,14 @@ import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toNms
+import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.chat.SignedMessage
+import net.kyori.adventure.text.Component
+import net.minecraft.network.chat.OutgoingChatMessage
+import net.minecraft.network.chat.PlayerChatMessage
 import net.minecraft.server.network.ServerGamePacketListenerImpl
 import net.minecraft.util.FutureChain
 import org.bukkit.entity.Player
@@ -47,6 +53,30 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
             chatMessageChain.append(done) { /* no-op */ }
         }
+    }
+
+    override fun sendSignedMessageWithChangedContent(
+        player: Player,
+        original: SignedMessage,
+        boundChatType: ChatType.Bound,
+        unsignedContent: Component
+    ) {
+        if (original !is PlayerChatMessage.AdventureView) {
+            if (original.isSystem) {
+                player.sendMessage(unsignedContent, boundChatType)
+            } else {
+                player.sendMessage(unsignedContent, boundChatType)
+            }
+            return
+        }
+        val nmsPlayer = player.toNms()
+
+        nmsPlayer.sendChatMessage(
+            OutgoingChatMessage.create(original.playerChatMessage()),
+            nmsPlayer.isTextFilteringEnabled,
+            boundChatType.toNms(nmsPlayer),
+            PaperAdventure.asVanilla(unsignedContent)
+        )
     }
 
     @Suppress("ObjectPrivatePropertyName")

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/extensions/nms-extensions.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/extensions/nms-extensions.kt
@@ -10,11 +10,14 @@ import io.papermc.paper.adventure.PaperAdventure
 import io.papermc.paper.math.BlockPosition
 import io.papermc.paper.math.FinePosition
 import io.papermc.paper.math.Position
+import net.kyori.adventure.chat.ChatType
 import net.minecraft.advancements.AdvancementType
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Holder
+import net.minecraft.core.registries.Registries
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
+import net.minecraft.resources.ResourceKey
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.Display
@@ -54,6 +57,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 import org.spongepowered.math.imaginary.Quaternionf
 import org.spongepowered.math.vector.Vector3f
+import java.util.*
 import net.kyori.adventure.text.Component as AdventureComponent
 import net.minecraft.world.item.ItemStack as NmsItemStack
 import net.minecraft.world.level.block.state.BlockState as NmsBlockState
@@ -152,3 +156,13 @@ fun AdvancementDisplay.Frame.toNms() = when (this) {
 
 fun NamespacedKey.toIdentifier() = Identifier.fromNamespaceAndPath(namespace, key)
 fun GameMode.toNms() = GameType.byId(this.value)
+
+fun ChatType.Bound.toNms(sender: ServerPlayer): net.minecraft.network.chat.ChatType.Bound {
+    val chatTypeLookup = sender.level().registryAccess().lookupOrThrow(Registries.CHAT_TYPE)
+
+    return net.minecraft.network.chat.ChatType.Bound(
+        chatTypeLookup.getOrThrow(ResourceKey.create(Registries.CHAT_TYPE, PaperAdventure.asVanilla(type().key()))),
+        PaperAdventure.asVanilla(name()),
+        Optional.ofNullable(PaperAdventure.asVanilla(target()))
+    )
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -4,8 +4,14 @@ import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import dev.slne.surf.api.paper.server.nms.v26_1.extensions.toNms
+import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.chat.SignedMessage
+import net.kyori.adventure.text.Component
+import net.minecraft.network.chat.OutgoingChatMessage
+import net.minecraft.network.chat.PlayerChatMessage
 import net.minecraft.server.network.ServerGamePacketListenerImpl
 import net.minecraft.util.FutureChain
 import org.bukkit.entity.Player
@@ -47,6 +53,30 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
             chatMessageChain.append(done) { /* no-op */ }
         }
+    }
+
+    override fun sendSignedMessageWithChangedContent(
+        player: Player,
+        original: SignedMessage,
+        boundChatType: ChatType.Bound,
+        unsignedContent: Component
+    ) {
+        if (original !is PlayerChatMessage.AdventureView) {
+            if (original.isSystem) {
+                player.sendMessage(unsignedContent, boundChatType)
+            } else {
+                player.sendMessage(unsignedContent, boundChatType)
+            }
+            return
+        }
+        val nmsPlayer = player.toNms()
+
+        nmsPlayer.sendChatMessage(
+            OutgoingChatMessage.create(original.playerChatMessage()),
+            nmsPlayer.isTextFilteringEnabled,
+            boundChatType.toNms(nmsPlayer),
+            PaperAdventure.asVanilla(unsignedContent)
+        )
     }
 
     @Suppress("ObjectPrivatePropertyName")

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/extensions/nms-extensions.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/extensions/nms-extensions.kt
@@ -10,11 +10,14 @@ import io.papermc.paper.adventure.PaperAdventure
 import io.papermc.paper.math.BlockPosition
 import io.papermc.paper.math.FinePosition
 import io.papermc.paper.math.Position
+import net.kyori.adventure.chat.ChatType
 import net.minecraft.advancements.AdvancementType
 import net.minecraft.core.BlockPos
 import net.minecraft.core.Holder
+import net.minecraft.core.registries.Registries
 import net.minecraft.network.chat.Component
 import net.minecraft.resources.Identifier
+import net.minecraft.resources.ResourceKey
 import net.minecraft.server.level.ServerLevel
 import net.minecraft.server.level.ServerPlayer
 import net.minecraft.world.entity.Display
@@ -54,6 +57,7 @@ import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.ItemType
 import org.spongepowered.math.imaginary.Quaternionf
 import org.spongepowered.math.vector.Vector3f
+import java.util.*
 import net.kyori.adventure.text.Component as AdventureComponent
 import net.minecraft.world.item.ItemStack as NmsItemStack
 import net.minecraft.world.level.block.state.BlockState as NmsBlockState
@@ -152,3 +156,13 @@ fun AdvancementDisplay.Frame.toNms() = when (this) {
 
 fun NamespacedKey.toIdentifier() = Identifier.fromNamespaceAndPath(namespace, key)
 fun GameMode.toNms() = GameType.byId(this.value)
+
+fun ChatType.Bound.toNms(sender: ServerPlayer): net.minecraft.network.chat.ChatType.Bound {
+    val chatTypeLookup = sender.level().registryAccess().lookupOrThrow(Registries.CHAT_TYPE)
+
+    return net.minecraft.network.chat.ChatType.Bound(
+        chatTypeLookup.getOrThrow(ResourceKey.create(Registries.CHAT_TYPE, PaperAdventure.asVanilla(type().key()))),
+        PaperAdventure.asVanilla(name()),
+        Optional.ofNullable(PaperAdventure.asVanilla(target()))
+    )
+}

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1714,12 +1714,14 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
 }
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -4,6 +4,9 @@ import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import kotlinx.coroutines.CoroutineScope
+import net.kyori.adventure.chat.ChatType
+import net.kyori.adventure.chat.SignedMessage
+import net.kyori.adventure.text.Component
 import org.bukkit.entity.Player
 import org.jetbrains.annotations.ApiStatus
 
@@ -14,6 +17,13 @@ interface SurfPaperNmsPlayerBridge {
     fun getRemoteChatSessionData(player: Player): RemoteChatSessionData?
 
     fun runOnChatMessageChain(player: Player, scope: CoroutineScope, block: suspend () -> Unit)
+
+    fun sendSignedMessageWithChangedContent(
+        player: Player,
+        original: SignedMessage,
+        boundChatType: ChatType.Bound,
+        unsignedContent: Component
+    )
 
     companion object : SurfPaperNmsPlayerBridge by playerBridge {
         val INSTANCE get() = playerBridge


### PR DESCRIPTION
This pull request introduces a new API method for sending signed chat messages with modified content, and implements this method for both Minecraft 1.21.11 and 1.26.1 NMS bridges. It also provides the necessary extension functions for converting Adventure `ChatType.Bound` to its NMS equivalent. The version is bumped to 3.7.0 to reflect these API changes.

### New API and Implementation

* Added a new abstract method `sendSignedMessageWithChangedContent` to the `SurfPaperNmsPlayerBridge` interface, allowing plugins to send signed messages with custom unsigned content. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR21-R27) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1717-R1724)
* Implemented `sendSignedMessageWithChangedContent` in both `V1_21_11SurfPaperNmsPlayerBridgeImpl` and `V26_1SurfPaperNmsPlayerBridgeImpl`, handling both system and player chat messages and using NMS methods for correct message dispatch. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R58-R81) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R58-R81)

### NMS Extension Utilities

* Added an extension function to convert Adventure `ChatType.Bound` to the corresponding NMS type, used in the new message-sending logic. [[1]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR159-R168) [[2]](diffhunk://#diff-eaa56ec46ddc67933569ac732dafa0d5074fc26f2c3fb615b32d6a298f047a0bR159-R168)

### Dependency and Version Updates

* Updated `gradle.properties` to bump the project version from 3.6.0 to 3.7.0 to reflect the new API addition.

### Imports and Housekeeping

* Added necessary imports for new classes and utilities in implementation and extension files. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R7-R14) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R7-R14) [[3]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR13-R20) [[4]](diffhunk://#diff-eaa56ec46ddc67933569ac732dafa0d5074fc26f2c3fb615b32d6a298f047a0bR13-R20) [[5]](diffhunk://#diff-2861ccb673928c4b8f71e2e71e1bb550144654490e7f5c1447013284e35946bfR60) [[6]](diffhunk://#diff-eaa56ec46ddc67933569ac732dafa0d5074fc26f2c3fb615b32d6a298f047a0bR60) [[7]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR7-R9)