### PR TITLE
Implement BitSet serialization and enhance player chat handling

### DIFF
--- a/.github/git-commit-instructions.md
+++ b/.github/git-commit-instructions.md
@@ -1,32 +1,62 @@
 # Git Commit Message Guide
 
+## CRITICAL: Ignore Commit History
+
+Do NOT use the repository's existing commit history as examples
+or context for generating commit messages. Base your output
+EXCLUSIVELY on this specification and the provided diff.
+The commit history may contain incorrect type classifications.
+Always determine the type (feat, fix, refactor, etc.) solely
+from the nature of the code changes in the diff.
+
 ## Role and Purpose
 
-You will act as a git commit message generator. When receiving a git diff, you will ONLY output the commit message itself, nothing else. No explanations, no questions, no additional comments.
+You will act as a git commit message generator. When receiving a git diff, you will ONLY output the commit message
+itself, nothing else. No explanations, no questions, no additional comments.
 
-Commits should follow the Conventional Commits 1.0.0 specification and be further refined using the rules outlined below.
+Commits should follow the Conventional Commits 1.0.0 specification and be further refined using the rules outlined
+below.
 
 ## The [Conventional Commits 1.0.0 Specification](https://www.conventionalcommits.org/en/v1.0.0/):
 
-The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and “OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
+The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL NOT”, “SHOULD”, “SHOULD NOT”, “RECOMMENDED”, “MAY”, and
+“OPTIONAL” in this document are to be interpreted as described in [RFC 2119](https://www.ietf.org/rfc/rfc2119.txt).
 
-1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope, OPTIONAL `!`, and REQUIRED terminal colon and space.
+1. Commits MUST be prefixed with a type, which consists of a noun, `feat`, `fix`, etc., followed by the OPTIONAL scope,
+   OPTIONAL `!`, and REQUIRED terminal colon and space.
 2. The type `feat` MUST be used when a commit adds a new feature to your application or library.
 3. The type `fix` MUST be used when a commit represents a bug fix for your application.
-4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., `fix(parser)`:
-5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
-6. A longer commit body MAY be provided after the short description, providing additional contextual information about the code changes. The body MUST begin one blank line after the description.
+4. A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded
+   by parenthesis, e.g., `fix(parser)`:
+5. A description MUST immediately follow the colon and space after the type/scope prefix. The description is a short
+   summary of the code changes, e.g., fix: array parsing issue when multiple spaces were contained in string.
+6. A longer commit body MAY be provided after the short description, providing additional contextual information about
+   the code changes. The body MUST begin one blank line after the description.
 7. A commit body is free-form and MAY consist of any number of newline separated paragraphs.
-8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the git trailer convention).
-9. A footer’s token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a token.
-10. A footer’s value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer token/separator pair is observed.
+8. One or more footers MAY be provided one blank line after the body. Each footer MUST consist of a word token, followed
+   by either a `:<space>` or `<space>#` separator, followed by a string value (this is inspired by the git trailer
+   convention).
+9. A footer’s token MUST use `-` in place of whitespace characters, e.g., `Acked-by` (this helps differentiate the
+   footer section from a multi-paragraph body). An exception is made for `BREAKING CHANGE`, which MAY also be used as a
+   token.
+10. A footer’s value MAY contain spaces and newlines, and parsing MUST terminate when the next valid footer
+    token/separator pair is observed.
 11. Breaking changes MUST be indicated in the type/scope prefix of a commit, or as an entry in the footer.
-12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon, space, and description, e.g. BREAKING CHANGE: environment variables now take precedence over config files.
-13. If included in the type/scope prefix, breaking changes MUST be indicated by a `!` immediately before the `:`. If `!` is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to describe the breaking change.
+12. If included as a footer, a breaking change MUST consist of the uppercase text BREAKING CHANGE, followed by a colon,
+    space, and description, e.g. BREAKING CHANGE: environment variables now take precedence over config files.
+13. If included in the type/scope prefix, breaking changes MUST be indicated by a `!` immediately before the `:`. If `!`
+    is used, BREAKING CHANGE: MAY be omitted from the footer section, and the commit description SHALL be used to
+    describe the breaking change.
 14. Types other than `feat` and `fix` MAY be used in your commit messages, e.g., docs: update ref docs.
-15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors, with the exception of BREAKING CHANGE which MUST be uppercase.
+15. The units of information that make up Conventional Commits MUST NOT be treated as case sensitive by implementors,
+    with the exception of BREAKING CHANGE which MUST be uppercase.
 16. BREAKING-CHANGE MUST be synonymous with BREAKING CHANGE, when used as a token in a footer.
-17. For Commits that include dependency updates, the body MUST include a list of all updated DIRECT dependencies with the versions they were updated from and the versions to which they were updated to. When a diff includes both package manifest files (package.json, Cargo.toml, pyproject.toml, etc.) and lockfiles (pnpm-lock.yaml, package-lock.json, yarn.lock, Cargo.lock, poetry.lock, etc.), ONLY the direct dependencies explicitly changed in the manifest file MUST be listed. Transitive dependency changes visible only in lockfiles MUST NOT be included, as they are automatic consequences of direct dependency updates.
+17. For Commits that include dependency updates, the body MUST include a list of all updated DIRECT dependencies with
+    the versions they were updated from and the versions to which they were updated to. When a diff includes both
+    package manifest files (package.json, Cargo.toml, pyproject.toml, etc.) and lockfiles (pnpm-lock.yaml,
+    package-lock.json, yarn.lock, Cargo.lock, poetry.lock, etc.), ONLY the direct dependencies explicitly changed in the
+    manifest file MUST be listed. Transitive dependency changes visible only in lockfiles MUST NOT be included, as they
+    are automatic consequences of direct dependency updates.
 
 ## Output Format
 
@@ -42,7 +72,8 @@ The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “SHALL 
 
 ### Multiple Distinct Changes
 
-When the provided diff contains changes that address SEPARATE, UNRELATED concerns, use this format to document each distinct change with its own subject line:
+When the provided diff contains changes that address SEPARATE, UNRELATED concerns, use this format to document each
+distinct change with its own subject line:
 
 ```
 <emoji> <type>(<scope>): <description>
@@ -75,7 +106,8 @@ When the provided diff contains changes that address SEPARATE, UNRELATED concern
 - ❌ All changes serve one purpose: "refactor code style" affecting 3 files → Use SINGLE format
 - ❌ Changes are related: "add user profile feature" affecting multiple files → Use SINGLE format
 - ❌ Same type of work in multiple areas: "fix validation bugs in auth, payments, checkout" → Use SINGLE format
-- ❌ Related file changes: updating package.json AND pnpm-lock.yaml for dependencies → Use SINGLE format (these are part of one logical change)
+- ❌ Related file changes: updating package.json AND pnpm-lock.yaml for dependencies → Use SINGLE format (these are part
+  of one logical change)
 
 **Key question:** Can the changes be described under ONE logical purpose/concern?
 
@@ -85,37 +117,41 @@ When the provided diff contains changes that address SEPARATE, UNRELATED concern
 ## Type Reference
 
 | Type     | Title                    | Emoji | Description                                                                                            | Example Scopes (non-exaustive)                                |
-| -------- | ------------------------ | ----- | ------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------- |
-| build    | Builds                   | 🏗️    | Changes that affect the build system or external dependencies                                          | gulp, broccoli, npm                                           |
-| chore    | Chores                   | 🔧    | Other changes that don't modify src or test files                                                      | scripts, config                                               |
+|----------|--------------------------|-------|--------------------------------------------------------------------------------------------------------|---------------------------------------------------------------|
+| build    | Builds                   | 🏗️   | Changes that affect the build system or external dependencies                                          | gulp, broccoli, npm                                           |
+| chore    | Chores                   | 🔧    | Other changes that don't modify src or test files                                                      | scripts, config, abi                                          |
 | ci       | Continuous Integrations  | 👷    | Changes to our CI configuration files and scripts                                                      | Travis, Circle, BrowserStack, SauceLabs,github actions, husky |
 | docs     | Documentation            | 📝    | Documentation only changes                                                                             | README, API                                                   |
-| feat     | Features                 | ✨    | A new feature                                                                                          | user, payment, gallery                                        |
+| feat     | Features                 | ✨     | A new feature                                                                                          | user, payment, gallery                                        |
 | fix      | Bug Fixes                | 🐛    | A bug fix                                                                                              | auth, data                                                    |
-| perf     | Performance Improvements | ⚡️   | A code change that improves performance                                                                | query, cache                                                  |
+| perf     | Performance Improvements | ⚡️    | A code change that improves performance                                                                | query, cache                                                  |
 | refactor | Code Refactoring         | ♻️    | A code change that neither fixes a bug nor adds a feature                                              | utils, helpers                                                |
-| revert   | Reverts                  | ⏪️   | Reverts a previous commit                                                                              | query, utils,                                                 |
+| revert   | Reverts                  | ⏪️    | Reverts a previous commit                                                                              | query, utils,                                                 |
 | style    | Styles                   | 💄    | Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc) | formatting                                                    |
-| test     | Tests                    | ✅    | Adding missing tests or correcting existing tests                                                      | unit, e2e                                                     |
+| test     | Tests                    | ✅     | Adding missing tests or correcting existing tests                                                      | unit, e2e                                                     |
 | i18n     |                          | 🌐    | Internationalization                                                                                   | locale, translation                                           |
 
 ## More information about types
 
 ### build
 
-Used when a commit affects the build system or external dependencies. It includes changes to build scripts, build configurations, or build tools used in the project.
+Used when a commit affects the build system or external dependencies. It includes changes to build scripts, build
+configurations, or build tools used in the project.
 
 ### chore
 
-Typically used for routine or miscellaneous tasks related to the project, such as code reformatting, updating dependencies, or making general project maintenance.
+Typically used for routine or miscellaneous tasks related to the project, such as code reformatting, updating
+dependencies, or making general project maintenance.
 
 ### ci
 
-CI stands for continuous integration. This type is used for changes to the project's continuous integration or deployment configurations, scripts, or infrastructure.
+CI stands for continuous integration. This type is used for changes to the project's continuous integration or
+deployment configurations, scripts, or infrastructure.
 
 ### docs
 
-Documentation plays a vital role in software projects. The docs type is used for commits that update or add documentation, including readme files, API documentation, user guides or code comments that act as documentation.
+Documentation plays a vital role in software projects. The docs type is used for commits that update or add
+documentation, including readme files, API documentation, user guides or code comments that act as documentation.
 
 ### feat
 
@@ -123,23 +159,29 @@ Used for commits that introduce new features or functionalities to the project.
 
 ### fix
 
-Commits typed as fix address bug fixes or resolve issues in the codebase. They indicate corrections to existing features or functionality.
+Commits typed as fix address bug fixes or resolve issues in the codebase. They indicate corrections to existing features
+or functionality.
 
 ### perf
 
-Short for performance, this type is used when a commit improves the performance of the code or optimizes certain functionalities.
+Short for performance, this type is used when a commit improves the performance of the code or optimizes certain
+functionalities.
 
 ### refactor
 
-Commits typed as refactor involve making changes to the codebase that neither fix a bug nor add a new feature. Refactoring aims to improve code structure, organization, or efficiency without changing external behavior.
+Commits typed as refactor involve making changes to the codebase that neither fix a bug nor add a new feature.
+Refactoring aims to improve code structure, organization, or efficiency without changing external behavior.
 
 ### revert
 
-Commits typed as revert are used to undo previous commits. They are typically used to reverse changes made in previous commits.
+Commits typed as revert are used to undo previous commits. They are typically used to reverse changes made in previous
+commits.
 
 ### style
 
-The style type is used for commits that focus on code style changes, such as formatting, indentation, or whitespace modifications. These commits do not affect the functionality of the code but improve its readability and maintainability.
+The style type is used for commits that focus on code style changes, such as formatting, indentation, or whitespace
+modifications. These commits do not affect the functionality of the code but improve its readability and
+maintainability.
 
 ### test
 
@@ -147,7 +189,108 @@ Used for changes that add or modify test cases, test frameworks, or other relate
 
 ### i18n
 
-This type is used for commits that involve changes related to internationalization or localization. It includes changes to localization files, translations, or internationalization-related configurations.
+This type is used for commits that involve changes related to internationalization or localization. It includes changes
+to localization files, translations, or internationalization-related configurations.
+
+## Type Decision Guide (MUST follow, overrides any prior context)
+
+IGNORE the repository's existing commit history when choosing a type.
+Determine the type EXCLUSIVELY from the nature of the code changes
+in the diff using the following decision tree:
+
+### Decision Tree
+
+Ask these questions IN ORDER about the diff:
+
+1. Does it revert a previous commit?
+   → `revert`
+
+2. Does it ONLY change documentation or code comments
+   (no logic changes)?
+   → `docs`
+
+3. Does it ONLY change CI/CD configuration files
+   (GitHub Actions, Jenkins, Docker CI, Husky, etc.)?
+   → `ci`
+
+4. Does it ONLY change build scripts, build config,
+   or dependency manifests?
+   → `build` (build system changes) or `chore` (dependency updates)
+
+5. Does it ONLY change `.api` files (Kotlin ABI dump files generated by
+   the Kotlin Binary Compatibility Validator via `updateKotlinAbi`)?
+   → `chore` with scope `abi`
+   These files are generated artifacts reflecting the public API surface.
+   Treat them like lockfiles: they are consequences of source changes,
+   NOT source changes themselves.
+   Use `chore(abi): update api dump` or similar.
+   NEVER classify `.api` file changes as `feat`, `fix`, or `refactor`.
+
+6. Does it ONLY change translations or locale files?
+   → `i18n`
+
+7. Does it ONLY add or modify tests (no production code)?
+   → `test`
+
+8. Does it ONLY change formatting, whitespace, semicolons,
+   or code style without affecting logic?
+   → `style`
+
+9. Does it fix incorrect behavior, prevent crashes, infinite
+   loops, duplicate processing, data corruption, race
+   conditions, or add missing safety guards to EXISTING
+   functionality?
+   → `fix`
+
+10. Does it improve performance of existing functionality
+    (caching, query optimization, reducing allocations, etc.)?
+    → `perf`
+
+11. Does it introduce ENTIRELY NEW user-facing functionality
+    that did not exist before (new endpoint, new command,
+    new UI element, new capability)?
+    → `feat`
+
+12. Does it restructure, rename, or reorganize existing code
+    without changing external behavior and without fixing
+    a bug?
+    → `refactor`
+
+13. Everything else (config, scripts, tooling, maintenance):
+    → `chore`
+
+### Common Misclassifications to AVOID
+
+| Change                                   | ❌ WRONG           | ✅ CORRECT  |
+|------------------------------------------|-------------------|------------|
+| Add bounds/limits to prevent loops       | feat              | fix        |
+| Add null checks or validation guards     | feat              | fix        |
+| Add deduplication to existing process    | feat              | fix        |
+| Add retry logic to prevent failures      | feat              | fix        |
+| Add logging/metrics to existing code     | feat              | refactor   |
+| Add timeout to existing operation        | feat              | fix        |
+| Pass additional parameter to existing fn | feat              | refactor   |
+| Rename variables or functions            | feat              | refactor   |
+| Extract method from existing code        | feat              | refactor   |
+| Update dependency versions               | feat              | chore      |
+| Add error handling to existing flow      | feat              | fix        |
+| Add index or cache for performance       | feat              | perf       |
+| Update .api dump files (Kotlin ABI)      | feat/fix/refactor | chore      |
+| Add new entries to .api dump             | feat              | chore(abi) |
+| Remove entries from .api dump            | fix               | chore(abi) |
+
+### Key Distinction: feat vs fix vs refactor
+
+- **feat**: A completely NEW capability is introduced.
+  The user/system can do something it could NOT do before.
+- **fix**: EXISTING functionality worked incorrectly or
+  could fail. The change prevents that failure.
+- **refactor**: EXISTING functionality continues to work
+  the same way, but the code is restructured internally.
+
+If in doubt between `feat` and `fix`, ask: "Was the previous
+behavior correct?" If NO → `fix`. If YES and new behavior is
+added → `feat`.
 
 ## Writing Rules
 
@@ -164,7 +307,8 @@ Format: `<emoji> <type>[optional (<scope>)]: <description>`
 
 **When to include scope:**
 
-- The change affects a specific, identifiable component, module, or area (e.g., `auth`, `api`, `database`, `infra`, `terraform`, )
+- The change affects a specific, identifiable component, module, or area (e.g., `auth`, `api`, `database`, `infra`,
+  `terraform`, )
 - Including scope adds clarity about what part of the codebase changed
 - The scope has been given as part of the [Additional Context](#additional-context)
 - The scope is clear from the file paths or nature of changes
@@ -182,12 +326,14 @@ Format: `<emoji> <type>[optional (<scope>)]: <description>`
 - Bullet points that exceed the 100 characters per line count should use line breaks without adding extra bullet points
 - Explain what and why, using ONLY factual, verifiable information from the diff
 - Be objective and precise - describe EXACTLY what changed without subjective interpretations
-- AVOID vague qualifiers like "for clarity", "for consistency", "improve readability" unless the diff explicitly shows formatting/style changes
+- AVOID vague qualifiers like "for clarity", "for consistency", "improve readability" unless the diff explicitly shows
+  formatting/style changes
 - ONLY include reasoning (the "why") when:
-    - It is provided in [Additional Context](#additional-context)
-    - It is clearly evident from the code context or commit scope
-    - It is objectively verifiable from the diff itself
-- Omit the body entirely if the subject line is self-explanatory and no [Additional Context](#additional-context) is provided
+  - It is provided in [Additional Context](#additional-context)
+  - It is clearly evident from the code context or commit scope
+  - It is objectively verifiable from the diff itself
+- Omit the body entirely if the subject line is self-explanatory and no [Additional Context](#additional-context) is
+  provided
 - Must be in English
 
 ### Footer
@@ -258,7 +404,8 @@ Reviewed-by: John Smith <john.smith@example.com>
 
 ##### Signed-off-by
 
-Purpose: To indicate that the commit complies with the project’s contribution guidelines, often seen in projects using the Developer Certificate of Origin (DCO).
+Purpose: To indicate that the commit complies with the project’s contribution guidelines, often seen in projects using
+the Developer Certificate of Origin (DCO).
 Example:
 
 ```
@@ -287,7 +434,8 @@ When additional context is present:
 
 - Consider it carefully when generating the commit message
 - Incorporate relevant information into the commit body as appropriate
-- The context may clarify what changed, explain why, explain the scope, the type or provide any other relevant information
+- The context may clarify what changed, explain why, explain the scope, the type or provide any other relevant
+  information
 - Maintain all formatting rules (100 character limit, bullet points, etc.)
 - Still base the description of WHAT changed primarily on the diff itself
 - Use the additional context to supplement or clarify information as needed
@@ -330,10 +478,12 @@ When a diff includes both package manifest files and lockfile changes:
 
 - **DO:** Only list direct dependencies explicitly updated in the manifest (package.json, Cargo.toml, etc.)
 - **DON'T:** List transitive dependencies that only appear in lockfile changes (pnpm-lock.yaml, Cargo.lock, etc.)
-- **Rationale:** Lockfile changes are automatic consequences of direct dependency updates and including them creates noise
+- **Rationale:** Lockfile changes are automatic consequences of direct dependency updates and including them creates
+  noise
 
 Examples of manifest files: `package.json`, `Cargo.toml`, `pyproject.toml`, `go.mod`, `Gemfile`
-Examples of lockfiles: `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, `poetry.lock`, `go.sum`, `Gemfile.lock`
+Examples of lockfiles: `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `Cargo.lock`, `poetry.lock`, `go.sum`,
+`Gemfile.lock`
 
 ## Critical Requirements
 
@@ -356,7 +506,8 @@ Examples of lockfiles: `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock`, `Carg
 
 ### Example 1 - Variable Refactoring
 
-This example demonstrates a simple refactoring change where a port configuration is changed to use environment variables.
+This example demonstrates a simple refactoring change where a port configuration is changed to use environment
+variables.
 
 **EXAMPLE INPUT:**
 
@@ -415,7 +566,8 @@ index af76bc0..781d472 100644
 
 ### Example 3 - Multiple Dependency Updates
 
-This example demonstrates updating multiple related packages. Only list direct dependencies from package.json, ignore transitive lockfile changes.
+This example demonstrates updating multiple related packages. Only list direct dependencies from package.json, ignore
+transitive lockfile changes.
 
 **EXAMPLE INPUT:**
 
@@ -458,7 +610,8 @@ diff --git a/pnpm-lock.yaml b/pnpm-lock.yaml
 
 ### Example 4 - Single Dependency Update with Lockfile
 
-This example shows how to handle a single dependency update where the diff includes both package.json and lockfile changes. Focus only on the direct dependency change from package.json.
+This example shows how to handle a single dependency update where the diff includes both package.json and lockfile
+changes. Focus only on the direct dependency change from package.json.
 
 **EXAMPLE INPUT:**
 
@@ -519,7 +672,9 @@ index 5160b59..aa9c5bd 100644
 🔧 chore(deps): update playwright to 1.56.1
 ```
 
-**Explanation:** Even though the lockfile shows many transitive changes (playwright-core, @vitest/browser references, etc.), we only document the single direct dependency that was intentionally updated in package.json. The lockfile changes are an automatic consequences of this update.
+**Explanation:** Even though the lockfile shows many transitive changes (playwright-core, @vitest/browser references,
+etc.), we only document the single direct dependency that was intentionally updated in package.json. The lockfile
+changes are an automatic consequences of this update.
 
 ### Example 5 - Multiple Distinct Changes
 
@@ -667,6 +822,37 @@ return (
 - add "Database" prefix to backup completion and file path messages
 ```
 
+### Example 6 - Kotlin ABI Dump Update
+
+This example demonstrates that `.api` files are generated artifacts and
+must always be classified as `chore`, regardless of what was added or removed.
+
+**EXAMPLE INPUT:**
+
+```
+diff --git a/lib/api/mylib.api b/lib/api/mylib.api
+index 3a1b2c..9f4e5d 100644
+--- a/lib/api/mylib.api
++++ b/lib/api/mylib.api
+@@ -12,6 +12,9 @@ public final class com/example/MyClass {
+   public final fun doSomething ()V
++  public final fun doSomethingNew ()V
+ }
+```
+
+**EXAMPLE OUTPUT:**
+
+```
+🔧 chore(abi): update api dump
+```
+
+**Explanation:** `.api` files are generated by the Kotlin Binary Compatibility
+Validator (`updateKotlinAbi`). They reflect the public API surface but are
+not hand-written source code. Even when new public functions appear in the
+dump (which might stem from a `feat` commit), the dump file update itself
+is always `chore(abi)`.
+
+
 **━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━**
 **END OF EXAMPLES SECTION**
 **When you receive an ACTUAL git diff to process, it will appear below this line**
@@ -674,4 +860,5 @@ return (
 
 ## IMPORTANT
 
-Remember: All output MUST be in English language. You are to act as a pure commit message generator. Your response should contain NOTHING but the commit message itself.
+Remember: All output MUST be in English language. You are to act as a pure commit message generator. Your response
+should contain NOTHING but the commit message itself.

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.7.0
+version=3.8.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-core/surf-api-core/api/surf-api-core.api
+++ b/surf-api-core/surf-api-core/api/surf-api-core.api
@@ -8904,6 +8904,15 @@ public final class dev/slne/surf/api/core/serializer/adventure/title/AdventureTi
 	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Lnet/kyori/adventure/title/Title$Times;)V
 }
 
+public final class dev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer : kotlinx/serialization/KSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/util/BitSet;
+	public fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/util/BitSet;)V
+}
+
 public final class dev/slne/surf/api/core/serializer/java/crypt/publickey/PublicKeySerializer : kotlinx/serialization/KSerializer {
 	public static final field INSTANCE Ldev/slne/surf/api/core/serializer/java/crypt/publickey/PublicKeySerializer;
 	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/SurfSerializerModule.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/SurfSerializerModule.kt
@@ -11,6 +11,7 @@ import dev.slne.surf.api.core.serializer.adventure.resourcepack.info.AdventureRe
 import dev.slne.surf.api.core.serializer.adventure.sound.AdventureSoundSerializer
 import dev.slne.surf.api.core.serializer.adventure.sound.stop.AdventureSoundStopSerializer
 import dev.slne.surf.api.core.serializer.adventure.title.AdventureTitleSerializer
+import dev.slne.surf.api.core.serializer.java.bitset.BitSetSerializer
 import dev.slne.surf.api.core.serializer.java.crypt.publickey.PublicKeySerializer
 import dev.slne.surf.api.core.serializer.java.datetime.date.date.DateSerializer
 import dev.slne.surf.api.core.serializer.java.datetime.date.local.LocalDateSerializer
@@ -115,6 +116,7 @@ object SurfSerializerModule {
         contextual(URLSerializer)
         contextual(BigIntegerSerializer)
         contextual(BigDecimalSerializer)
+        contextual(BitSetSerializer)
     }
 
     val javaTime = SerializersModule {

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer.kt
@@ -12,7 +12,7 @@ typealias SerializableBitSet = @Serializable(with = BitSetSerializer::class) Bit
 
 object BitSetSerializer : KSerializer<BitSet> {
     private val longArraySerializer = LongArraySerializer()
-    override val descriptor = SerialDescriptor("dev.slne.surf.api.BitSet", longArraySerializer.descriptor)
+    override val descriptor = SerialDescriptor("surf.api.BitSet", longArraySerializer.descriptor)
 
     override fun serialize(encoder: Encoder, value: BitSet) {
         longArraySerializer.serialize(encoder, value.toLongArray())

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/serializer/java/bitset/BitSetSerializer.kt
@@ -1,0 +1,25 @@
+package dev.slne.surf.api.core.serializer.java.bitset
+
+import kotlinx.serialization.KSerializer
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.LongArraySerializer
+import kotlinx.serialization.descriptors.SerialDescriptor
+import kotlinx.serialization.encoding.Decoder
+import kotlinx.serialization.encoding.Encoder
+import java.util.*
+
+typealias SerializableBitSet = @Serializable(with = BitSetSerializer::class) BitSet
+
+object BitSetSerializer : KSerializer<BitSet> {
+    private val longArraySerializer = LongArraySerializer()
+    override val descriptor = SerialDescriptor("dev.slne.surf.api.BitSet", longArraySerializer.descriptor)
+
+    override fun serialize(encoder: Encoder, value: BitSet) {
+        longArraySerializer.serialize(encoder, value.toLongArray())
+    }
+
+    override fun deserialize(decoder: Decoder): BitSet {
+        val longArray = longArraySerializer.deserialize(decoder)
+        return BitSet.valueOf(longArray)
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
@@ -1,0 +1,98 @@
+package dev.slne.surf.api.paper.server.nms.v1_21_11.reflection;
+
+import net.minecraft.network.chat.FilterMask;
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.network.chat.MessageSignatureCache;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.util.FutureChain;
+import org.jspecify.annotations.NullMarked;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.BitSet;
+
+@NullMarked
+public final class NmsReflections {
+    private NmsReflections() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final VarHandle serverGamePacketListenerImpl$chatMessageChain;
+    private static final VarHandle serverGamePacketListenerImpl$nextChatIndex;
+    private static final VarHandle serverGamePacketListenerImpl$messageSignatureCache;
+    private static final VarHandle serverGamePacketListenerImpl$lastSeenMessages;
+
+    private static final MethodHandle filterMask$mask;
+    private static final MethodHandle filterMask$constructorBitSet;
+
+    public static FutureChain getChatMessageChain(ServerGamePacketListenerImpl instance) {
+        return (FutureChain) serverGamePacketListenerImpl$chatMessageChain.get(instance);
+    }
+
+    public static int increaseAndGetNextChatIndex(ServerGamePacketListenerImpl instance) {
+        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1) + 1;
+    }
+
+    public static MessageSignatureCache getMessageSignatureCache(ServerGamePacketListenerImpl instance) {
+        return (MessageSignatureCache) serverGamePacketListenerImpl$messageSignatureCache.get(instance);
+    }
+
+    public static LastSeenMessagesValidator getLastSeenMessages(ServerGamePacketListenerImpl instance) {
+        return (LastSeenMessagesValidator) serverGamePacketListenerImpl$lastSeenMessages.get(instance);
+    }
+
+    public static FilterMask createFilterMask(BitSet bitSet) throws Throwable {
+        return (FilterMask) filterMask$constructorBitSet.invokeExact(bitSet);
+    }
+
+    public static BitSet getMask(FilterMask filterMask) throws Throwable {
+        return (BitSet) filterMask$mask.invokeExact(filterMask);
+    }
+
+    static {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            MethodHandles.Lookup privateLookupInServerGamePacketListener = MethodHandles.privateLookupIn(ServerGamePacketListenerImpl.class, lookup);
+            MethodHandles.Lookup privateLookupInFilterMask = MethodHandles.privateLookupIn(FilterMask.class, lookup);
+
+            serverGamePacketListenerImpl$chatMessageChain = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "chatMessageChain",
+                    FutureChain.class
+            );
+
+            serverGamePacketListenerImpl$nextChatIndex = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "nextChatIndex",
+                    int.class
+            );
+
+            serverGamePacketListenerImpl$messageSignatureCache = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "messageSignatureCache",
+                    MessageSignatureCache.class
+            );
+
+            serverGamePacketListenerImpl$lastSeenMessages = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "lastSeenMessages",
+                    LastSeenMessagesValidator.class
+            );
+
+            filterMask$mask = privateLookupInFilterMask.findVirtual(
+                    FilterMask.class,
+                    "mask",
+                    MethodType.methodType(BitSet.class)
+            );
+
+            filterMask$constructorBitSet = privateLookupInFilterMask.findConstructor(
+                    FilterMask.class,
+                    MethodType.methodType(void.class, BitSet.class)
+            );
+        } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsCommonBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsCommonBridgeImpl.kt
@@ -11,15 +11,12 @@ import io.papermc.paper.configuration.GlobalConfiguration
 import net.kyori.adventure.text.Component
 import net.minecraft.network.protocol.common.ClientboundClearDialogPacket
 import net.minecraft.server.MinecraftServer
-import net.minecraft.server.network.ServerGamePacketListenerImpl
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.ComposterBlock
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.block.data.BlockData
 import org.bukkit.entity.Player
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.net.InetSocketAddress
 
 @NmsUseWithCaution
@@ -89,29 +86,5 @@ class V1_21_11SurfPaperNmsCommonBridgeImpl : SurfPaperNmsCommonBridge {
 
         return channel.channel().localAddress() as? InetSocketAddress
             ?: error("Local address is not an instance of InetSocketAddress")
-    }
-
-    @Suppress("USELESS_ELVIS")
-    override fun increaseNextChatIndex(player: Player) {
-        val connection = player.toNms().connection ?: return
-        `serverGamePacketListenerImpl$nextChatIndex`.getAndAdd(connection, 1)
-    }
-
-    @Suppress("ObjectPrivatePropertyName")
-    companion object {
-        @JvmStatic
-        private val `serverGamePacketListenerImpl$nextChatIndex`: VarHandle
-
-        init {
-            val lookup = MethodHandles.lookup()
-            val privateLookupInServerGamePacketListener =
-                MethodHandles.privateLookupIn(ServerGamePacketListenerImpl::class.java, lookup)
-
-            `serverGamePacketListenerImpl$nextChatIndex` = privateLookupInServerGamePacketListener.findVarHandle(
-                ServerGamePacketListenerImpl::class.java,
-                "nextChatIndex",
-                Int::class.javaPrimitiveType
-            )
-        }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -2,21 +2,20 @@ package dev.slne.surf.api.paper.server.nms.v1_21_11.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
+import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toNms
+import dev.slne.surf.api.paper.server.nms.v1_21_11.reflection.NmsReflections
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
-import net.minecraft.network.chat.OutgoingChatMessage
-import net.minecraft.network.chat.PlayerChatMessage
-import net.minecraft.server.network.ServerGamePacketListenerImpl
-import net.minecraft.util.FutureChain
+import net.minecraft.network.chat.*
+import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket
 import org.bukkit.entity.Player
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
+import java.util.*
 import java.util.concurrent.CompletableFuture
 
 @NmsUseWithCaution
@@ -36,7 +35,7 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     override fun runOnChatMessageChain(player: Player, scope: CoroutineScope, block: suspend () -> Unit) {
         val nmsPlayer = player.toNms()
         val connection = nmsPlayer.connection
-        val chatMessageChain = `serverGamePacketListenerImpl$chatMessageChain`.get(connection) as FutureChain
+        val chatMessageChain = NmsReflections.getChatMessageChain(connection)
         val done = CompletableFuture<Unit>()
 
         synchronized(chatMessageChain) {
@@ -79,22 +78,103 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
         )
     }
 
-    @Suppress("ObjectPrivatePropertyName")
-    companion object {
-        @JvmStatic
-        private val `serverGamePacketListenerImpl$chatMessageChain`: VarHandle
+    @Suppress("USELESS_ELVIS")
+    override fun increaseNextChatIndex(player: Player): Int? {
+        val connection = player.toNms().connection ?: return null
+        return NmsReflections.increaseAndGetNextChatIndex(connection)
+    }
 
-        init {
-            val lookup = MethodHandles.lookup()
-            val privateLookupInServerGamePacketListener =
-                MethodHandles.privateLookupIn(ServerGamePacketListenerImpl::class.java, lookup)
+    override fun createPlayerChatMessageMirrorFromAdventure(
+        adventure: SignedMessage,
+        unsignedContent: Component?
+    ): PlayerChatMessageMirror? {
+        if (adventure !is PlayerChatMessage.AdventureView) return null
+        val nms = adventure.playerChatMessage()
+        val nmsLink = nms.link
+        val nmsBody = nms.signedBody()
+        val nmsLastSeen = nmsBody.lastSeen()
 
-            `serverGamePacketListenerImpl$chatMessageChain` = privateLookupInServerGamePacketListener
-                .findVarHandle(
-                    ServerGamePacketListenerImpl::class.java,
-                    "chatMessageChain",
-                    FutureChain::class.java
+        val link = PlayerChatMessageMirror.SignedMessageLink(nmsLink.index(), nmsLink.sender(), nmsLink.sessionId())
+        val lastSeen = PlayerChatMessageMirror.SignedMessageBody.LastSeenMessages(
+            nmsLastSeen.entries().map { it.bytes() }
+        )
+        val body = PlayerChatMessageMirror.SignedMessageBody(
+            nmsBody.content(),
+            nmsBody.timeStamp(),
+            nmsBody.salt(),
+            lastSeen
+        )
+
+        val filterMask = when (val mask = nms.filterMask()) {
+            FilterMask.FULLY_FILTERED -> PlayerChatMessageMirror.FilterMask.FULLY_FILTERED
+            FilterMask.PASS_THROUGH -> PlayerChatMessageMirror.FilterMask.PASS_THROUGH
+            else -> PlayerChatMessageMirror.FilterMask(NmsReflections.getMask(mask))
+        }
+
+        return PlayerChatMessageMirror(
+            link = link,
+            signature = nms.signature()?.bytes(),
+            unsignedContent = unsignedContent,
+            signedBody = body,
+            filterMask = filterMask,
+        )
+    }
+
+    override fun createAdventureChatMessageFromMirror(mirror: PlayerChatMessageMirror): SignedMessage {
+        val mirrorLink = mirror.link
+        val mirrorBody = mirror.signedBody
+        val mirrorLastSeen = mirrorBody.lastSeen
+
+        val link = SignedMessageLink(mirrorLink.index, mirrorLink.sender, mirrorLink.sessionId)
+        val lastSeen = LastSeenMessages(mirrorLastSeen.entries.map(::MessageSignature))
+        val body = SignedMessageBody(mirrorBody.content, mirrorBody.timestamp, mirrorBody.salt, lastSeen)
+
+        val filterMask = when (mirror.filterMask) {
+            PlayerChatMessageMirror.FilterMask.FULLY_FILTERED -> FilterMask.FULLY_FILTERED
+            PlayerChatMessageMirror.FilterMask.PASS_THROUGH -> FilterMask.PASS_THROUGH
+            else -> NmsReflections.createFilterMask(mirror.filterMask.mask)
+        }
+
+        return PlayerChatMessage(
+            link,
+            mirror.signature?.let(::MessageSignature),
+            body,
+            PaperAdventure.asVanilla(mirror.unsignedContent),
+            filterMask
+        ).adventureView()
+    }
+
+    @Suppress("USELESS_ELVIS")
+    override fun sendPlayerChatMessage(receiver: Player, message: SignedMessage, boundChatType: ChatType.Bound) {
+        require(message is PlayerChatMessage.AdventureView) { "Only native nms messages can be sent" }
+        val nmsMessage = message.playerChatMessage()
+        val nmsPlayer = receiver.toNms()
+        val connection = nmsPlayer.connection ?: return
+        val messageSignatureCache = NmsReflections.getMessageSignatureCache(connection)
+
+        synchronized(messageSignatureCache) {
+            connection.send(
+                ClientboundPlayerChatPacket(
+                    NmsReflections.increaseAndGetNextChatIndex(connection),
+                    nmsMessage.link().sender(),
+                    nmsMessage.link().index(),
+                    nmsMessage.signature(),
+                    nmsMessage.signedBody().pack(messageSignatureCache),
+                    nmsMessage.unsignedContent(),
+                    nmsMessage.filterMask(),
+                    boundChatType.toNms(nmsPlayer)
                 )
+            )
+
+            val signature = nmsMessage.signature()
+            if (signature != null) {
+                messageSignatureCache.push(nmsMessage.signedBody(), signature)
+                val lastSeenMessages = NmsReflections.getLastSeenMessages(connection)
+
+                synchronized(lastSeenMessages) {
+                    lastSeenMessages.addPending(signature)
+                }
+            }
         }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
@@ -1,0 +1,98 @@
+package dev.slne.surf.api.paper.server.nms.v26_1.reflection;
+
+import net.minecraft.network.chat.FilterMask;
+import net.minecraft.network.chat.LastSeenMessagesValidator;
+import net.minecraft.network.chat.MessageSignatureCache;
+import net.minecraft.server.network.ServerGamePacketListenerImpl;
+import net.minecraft.util.FutureChain;
+import org.jspecify.annotations.NullMarked;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.lang.invoke.VarHandle;
+import java.util.BitSet;
+
+@NullMarked
+public final class NmsReflections {
+    private NmsReflections() {
+        throw new UnsupportedOperationException();
+    }
+
+    private static final VarHandle serverGamePacketListenerImpl$chatMessageChain;
+    private static final VarHandle serverGamePacketListenerImpl$nextChatIndex;
+    private static final VarHandle serverGamePacketListenerImpl$messageSignatureCache;
+    private static final VarHandle serverGamePacketListenerImpl$lastSeenMessages;
+
+    private static final MethodHandle filterMask$mask;
+    private static final MethodHandle filterMask$constructorBitSet;
+
+    public static FutureChain getChatMessageChain(ServerGamePacketListenerImpl instance) {
+        return (FutureChain) serverGamePacketListenerImpl$chatMessageChain.get(instance);
+    }
+
+    public static int increaseAndGetNextChatIndex(ServerGamePacketListenerImpl instance) {
+        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1) + 1;
+    }
+
+    public static MessageSignatureCache getMessageSignatureCache(ServerGamePacketListenerImpl instance) {
+        return (MessageSignatureCache) serverGamePacketListenerImpl$messageSignatureCache.get(instance);
+    }
+
+    public static LastSeenMessagesValidator getLastSeenMessages(ServerGamePacketListenerImpl instance) {
+        return (LastSeenMessagesValidator) serverGamePacketListenerImpl$lastSeenMessages.get(instance);
+    }
+
+    public static FilterMask createFilterMask(BitSet bitSet) throws Throwable {
+        return (FilterMask) filterMask$constructorBitSet.invokeExact(bitSet);
+    }
+
+    public static BitSet getMask(FilterMask filterMask) throws Throwable {
+        return (BitSet) filterMask$mask.invokeExact(filterMask);
+    }
+
+    static {
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            MethodHandles.Lookup privateLookupInServerGamePacketListener = MethodHandles.privateLookupIn(ServerGamePacketListenerImpl.class, lookup);
+            MethodHandles.Lookup privateLookupInFilterMask = MethodHandles.privateLookupIn(FilterMask.class, lookup);
+
+            serverGamePacketListenerImpl$chatMessageChain = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "chatMessageChain",
+                    FutureChain.class
+            );
+
+            serverGamePacketListenerImpl$nextChatIndex = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "nextChatIndex",
+                    int.class
+            );
+
+            serverGamePacketListenerImpl$messageSignatureCache = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "messageSignatureCache",
+                    MessageSignatureCache.class
+            );
+
+            serverGamePacketListenerImpl$lastSeenMessages = privateLookupInServerGamePacketListener.findVarHandle(
+                    ServerGamePacketListenerImpl.class,
+                    "lastSeenMessages",
+                    LastSeenMessagesValidator.class
+            );
+
+            filterMask$mask = privateLookupInFilterMask.findVirtual(
+                    FilterMask.class,
+                    "mask",
+                    MethodType.methodType(BitSet.class)
+            );
+
+            filterMask$constructorBitSet = privateLookupInFilterMask.findConstructor(
+                    FilterMask.class,
+                    MethodType.methodType(void.class, BitSet.class)
+            );
+        } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsCommonBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsCommonBridgeImpl.kt
@@ -11,15 +11,12 @@ import io.papermc.paper.configuration.GlobalConfiguration
 import net.kyori.adventure.text.Component
 import net.minecraft.network.protocol.common.ClientboundClearDialogPacket
 import net.minecraft.server.MinecraftServer
-import net.minecraft.server.network.ServerGamePacketListenerImpl
 import net.minecraft.world.level.block.Block
 import net.minecraft.world.level.block.ComposterBlock
 import org.bukkit.Bukkit
 import org.bukkit.Material
 import org.bukkit.block.data.BlockData
 import org.bukkit.entity.Player
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.net.InetSocketAddress
 
 @NmsUseWithCaution
@@ -90,29 +87,5 @@ class V26_1SurfPaperNmsCommonBridgeImpl : SurfPaperNmsCommonBridge {
 
         return channel.channel().localAddress() as? InetSocketAddress
             ?: error("Local address is not an instance of InetSocketAddress")
-    }
-
-    @Suppress("USELESS_ELVIS")
-    override fun increaseNextChatIndex(player: Player) {
-        val connection = player.toNms().connection ?: return
-        `serverGamePacketListenerImpl$nextChatIndex`.getAndAdd(connection, 1)
-    }
-
-    @Suppress("ObjectPrivatePropertyName")
-    companion object {
-        @JvmStatic
-        private val `serverGamePacketListenerImpl$nextChatIndex`: VarHandle
-
-        init {
-            val lookup = MethodHandles.lookup()
-            val privateLookupInServerGamePacketListener =
-                MethodHandles.privateLookupIn(ServerGamePacketListenerImpl::class.java, lookup)
-
-            `serverGamePacketListenerImpl$nextChatIndex` = privateLookupInServerGamePacketListener.findVarHandle(
-                ServerGamePacketListenerImpl::class.java,
-                "nextChatIndex",
-                Int::class.javaPrimitiveType
-            )
-        }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -2,21 +2,19 @@ package dev.slne.surf.api.paper.server.nms.v26_1.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
+import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import dev.slne.surf.api.paper.server.nms.v26_1.extensions.toNms
+import dev.slne.surf.api.paper.server.nms.v26_1.reflection.NmsReflections
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
-import net.minecraft.network.chat.OutgoingChatMessage
-import net.minecraft.network.chat.PlayerChatMessage
-import net.minecraft.server.network.ServerGamePacketListenerImpl
-import net.minecraft.util.FutureChain
+import net.minecraft.network.chat.*
+import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket
 import org.bukkit.entity.Player
-import java.lang.invoke.MethodHandles
-import java.lang.invoke.VarHandle
 import java.util.concurrent.CompletableFuture
 
 @NmsUseWithCaution
@@ -36,7 +34,7 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     override fun runOnChatMessageChain(player: Player, scope: CoroutineScope, block: suspend () -> Unit) {
         val nmsPlayer = player.toNms()
         val connection = nmsPlayer.connection
-        val chatMessageChain = `serverGamePacketListenerImpl$chatMessageChain`.get(connection) as FutureChain
+        val chatMessageChain = NmsReflections.getChatMessageChain(connection)
         val done = CompletableFuture<Unit>()
 
         synchronized(chatMessageChain) {
@@ -79,22 +77,103 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
         )
     }
 
-    @Suppress("ObjectPrivatePropertyName")
-    companion object {
-        @JvmStatic
-        private val `serverGamePacketListenerImpl$chatMessageChain`: VarHandle
+    @Suppress("USELESS_ELVIS")
+    override fun increaseNextChatIndex(player: Player): Int? {
+        val connection = player.toNms().connection ?: return null
+        return NmsReflections.increaseAndGetNextChatIndex(connection)
+    }
 
-        init {
-            val lookup = MethodHandles.lookup()
-            val privateLookupInServerGamePacketListener =
-                MethodHandles.privateLookupIn(ServerGamePacketListenerImpl::class.java, lookup)
+    override fun createPlayerChatMessageMirrorFromAdventure(
+        adventure: SignedMessage,
+        unsignedContent: Component?
+    ): PlayerChatMessageMirror? {
+        if (adventure !is PlayerChatMessage.AdventureView) return null
+        val nms = adventure.playerChatMessage()
+        val nmsLink = nms.link
+        val nmsBody = nms.signedBody()
+        val nmsLastSeen = nmsBody.lastSeen()
 
-            `serverGamePacketListenerImpl$chatMessageChain` = privateLookupInServerGamePacketListener
-                .findVarHandle(
-                    ServerGamePacketListenerImpl::class.java,
-                    "chatMessageChain",
-                    FutureChain::class.java
+        val link = PlayerChatMessageMirror.SignedMessageLink(nmsLink.index(), nmsLink.sender(), nmsLink.sessionId())
+        val lastSeen = PlayerChatMessageMirror.SignedMessageBody.LastSeenMessages(
+            nmsLastSeen.entries().map { it.bytes() }
+        )
+        val body = PlayerChatMessageMirror.SignedMessageBody(
+            nmsBody.content(),
+            nmsBody.timeStamp(),
+            nmsBody.salt(),
+            lastSeen
+        )
+
+        val filterMask = when (val mask = nms.filterMask()) {
+            FilterMask.FULLY_FILTERED -> PlayerChatMessageMirror.FilterMask.FULLY_FILTERED
+            FilterMask.PASS_THROUGH -> PlayerChatMessageMirror.FilterMask.PASS_THROUGH
+            else -> PlayerChatMessageMirror.FilterMask(NmsReflections.getMask(mask))
+        }
+
+        return PlayerChatMessageMirror(
+            link = link,
+            signature = nms.signature()?.bytes(),
+            unsignedContent = unsignedContent,
+            signedBody = body,
+            filterMask = filterMask,
+        )
+    }
+
+    override fun createAdventureChatMessageFromMirror(mirror: PlayerChatMessageMirror): SignedMessage {
+        val mirrorLink = mirror.link
+        val mirrorBody = mirror.signedBody
+        val mirrorLastSeen = mirrorBody.lastSeen
+
+        val link = SignedMessageLink(mirrorLink.index, mirrorLink.sender, mirrorLink.sessionId)
+        val lastSeen = LastSeenMessages(mirrorLastSeen.entries.map(::MessageSignature))
+        val body = SignedMessageBody(mirrorBody.content, mirrorBody.timestamp, mirrorBody.salt, lastSeen)
+
+        val filterMask = when (mirror.filterMask) {
+            PlayerChatMessageMirror.FilterMask.FULLY_FILTERED -> FilterMask.FULLY_FILTERED
+            PlayerChatMessageMirror.FilterMask.PASS_THROUGH -> FilterMask.PASS_THROUGH
+            else -> NmsReflections.createFilterMask(mirror.filterMask.mask)
+        }
+
+        return PlayerChatMessage(
+            link,
+            mirror.signature?.let(::MessageSignature),
+            body,
+            PaperAdventure.asVanilla(mirror.unsignedContent),
+            filterMask
+        ).adventureView()
+    }
+
+    @Suppress("USELESS_ELVIS")
+    override fun sendPlayerChatMessage(receiver: Player, message: SignedMessage, boundChatType: ChatType.Bound) {
+        require(message is PlayerChatMessage.AdventureView) { "Only native nms messages can be sent" }
+        val nmsMessage = message.playerChatMessage()
+        val nmsPlayer = receiver.toNms()
+        val connection = nmsPlayer.connection ?: return
+        val messageSignatureCache = NmsReflections.getMessageSignatureCache(connection)
+
+        synchronized(messageSignatureCache) {
+            connection.send(
+                ClientboundPlayerChatPacket(
+                    NmsReflections.increaseAndGetNextChatIndex(connection),
+                    nmsMessage.link().sender(),
+                    nmsMessage.link().index(),
+                    nmsMessage.signature(),
+                    nmsMessage.signedBody().pack(messageSignatureCache),
+                    nmsMessage.unsignedContent(),
+                    nmsMessage.filterMask(),
+                    boundChatType.toNms(nmsPlayer)
                 )
+            )
+
+            val signature = nmsMessage.signature()
+            if (signature != null) {
+                messageSignatureCache.push(nmsMessage.signedBody(), signature)
+                val lastSeenMessages = NmsReflections.getLastSeenMessages(connection)
+
+                synchronized(lastSeenMessages) {
+                    lastSeenMessages.addPending(signature)
+                }
+            }
         }
     }
 }

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1625,7 +1625,6 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun getStateId (Lorg/bukkit/Material;)I
 	public abstract fun getStateId (Lorg/bukkit/block/data/BlockData;)I
 	public abstract fun getVelocitySecret ()Ljava/lang/String;
-	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)V
 	public abstract fun isVelocityEnabled ()Z
 	public abstract fun nextEntityId ()I
 	public abstract fun removeCompostable (Lorg/bukkit/Material;)V
@@ -1643,7 +1642,6 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsCommonBridge$
 	public fun getStateId (Lorg/bukkit/Material;)I
 	public fun getStateId (Lorg/bukkit/block/data/BlockData;)I
 	public fun getVelocitySecret ()Ljava/lang/String;
-	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)V
 	public fun isVelocityEnabled ()Z
 	public fun nextEntityId ()I
 	public fun removeCompostable (Lorg/bukkit/Material;)V
@@ -1712,16 +1710,29 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsNbtBridge$Com
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion;
+	public abstract fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
+	public abstract fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public abstract fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
 	public abstract fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
+	public fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
+	public fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
+	public fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
 	public fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$DefaultImpls {
+	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 }
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge {
@@ -1734,6 +1745,173 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge$C
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge;
 	public fun getPlayerStatsAsJson (Lorg/bukkit/entity/Player;)Ljava/lang/String;
 	public fun savePlayerStatsToFile (Lorg/bukkit/entity/Player;)V
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$Companion;
+	public fun <init> (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;[BLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;Lnet/kyori/adventure/text/Component;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;)V
+	public final fun component1 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;
+	public final fun component2 ()[B
+	public final fun component3 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;
+	public final fun component4 ()Lnet/kyori/adventure/text/Component;
+	public final fun component5 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public final fun copy (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;[BLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;Lnet/kyori/adventure/text/Component;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;[BLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;Lnet/kyori/adventure/text/Component;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getFilterMask ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public final fun getLink ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;
+	public final fun getSignature ()[B
+	public final fun getSignedBody ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;
+	public final fun getUnsignedContent ()Lnet/kyori/adventure/text/Component;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$Companion;
+	public fun <init> (Ljava/util/BitSet;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;)V
+	public synthetic fun <init> (Ljava/util/BitSet;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/util/BitSet;
+	public final fun component2 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public final fun copy (Ljava/util/BitSet;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;Ljava/util/BitSet;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getMask ()Ljava/util/BitSet;
+	public final fun getType ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$Companion {
+	public final fun getFULLY_FILTERED ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public final fun getPASS_THROUGH ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask;
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE : java/lang/Enum {
+	public static final field FULLY_FILTERED Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public static final field PARTIALLY_FILTERED Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public static final field PASS_THROUGH Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+	public static fun values ()[Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$FilterMask$TYPE;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/time/Instant;JLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/time/Instant;
+	public final fun component3 ()J
+	public final fun component4 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;
+	public final fun copy (Ljava/lang/String;Ljava/time/Instant;JLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;Ljava/lang/String;Ljava/time/Instant;JLdev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getContent ()Ljava/lang/String;
+	public final fun getLastSeen ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;
+	public final fun getSalt ()J
+	public final fun getTimestamp ()Ljava/time/Instant;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages$Companion;
+	public fun <init> (Ljava/util/List;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun copy (Ljava/util/List;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;Ljava/util/List;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEntries ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageBody$LastSeenMessages$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink$Companion;
+	public fun <init> (ILjava/util/UUID;Ljava/util/UUID;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/UUID;
+	public final fun component3 ()Ljava/util/UUID;
+	public final fun copy (ILjava/util/UUID;Ljava/util/UUID;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;ILjava/util/UUID;Ljava/util/UUID;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getIndex ()I
+	public final fun getSender ()Ljava/util/UUID;
+	public final fun getSessionId ()Ljava/util/UUID;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsCommonBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsCommonBridge.kt
@@ -31,8 +31,6 @@ interface SurfPaperNmsCommonBridge {
 
     fun getServerIp(): InetSocketAddress
 
-    fun increaseNextChatIndex(player: Player)
-
     companion object : SurfPaperNmsCommonBridge by bridge {
         val INSTANCE get() = bridge
     }

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.api.paper.nms.bridges
 
 import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import kotlinx.coroutines.CoroutineScope
 import net.kyori.adventure.chat.ChatType
@@ -23,6 +24,21 @@ interface SurfPaperNmsPlayerBridge {
         original: SignedMessage,
         boundChatType: ChatType.Bound,
         unsignedContent: Component
+    )
+
+    fun increaseNextChatIndex(player: Player): Int?
+
+    fun createPlayerChatMessageMirrorFromAdventure(
+        adventure: SignedMessage,
+        unsignedContent: Component? = adventure.unsignedContent()
+    ): PlayerChatMessageMirror?
+
+    fun createAdventureChatMessageFromMirror(mirror: PlayerChatMessageMirror): SignedMessage
+
+    fun sendPlayerChatMessage(
+        receiver: Player,
+        message: SignedMessage,
+        boundChatType: ChatType.Bound
     )
 
     companion object : SurfPaperNmsPlayerBridge by playerBridge {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror.kt
@@ -1,0 +1,70 @@
+package dev.slne.surf.api.paper.nms.bridges.data.chat
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import net.kyori.adventure.text.Component
+import java.time.Instant
+import java.util.*
+
+@Serializable
+@NmsUseWithCaution
+data class PlayerChatMessageMirror(
+    val link: SignedMessageLink,
+    val signature: ByteArray?,
+    val signedBody: SignedMessageBody,
+    val unsignedContent: @Contextual Component?,
+    val filterMask: FilterMask,
+) {
+
+    @Serializable
+    data class FilterMask(val mask: @Contextual BitSet, val type: TYPE = TYPE.PARTIALLY_FILTERED) {
+        companion object {
+            val FULLY_FILTERED = FilterMask(BitSet(0), TYPE.FULLY_FILTERED)
+            val PASS_THROUGH = FilterMask(BitSet(0), TYPE.PASS_THROUGH)
+        }
+
+        enum class TYPE {
+            PASS_THROUGH,
+            FULLY_FILTERED,
+            PARTIALLY_FILTERED
+        }
+    }
+
+    @Serializable
+    data class SignedMessageLink(val index: Int, val sender: @Contextual UUID, val sessionId: @Contextual UUID)
+
+    @Serializable
+    data class SignedMessageBody(
+        val content: String,
+        val timestamp: @Contextual Instant,
+        val salt: Long,
+        val lastSeen: LastSeenMessages,
+    ) {
+
+        @Serializable
+        data class LastSeenMessages(val entries: List<ByteArray>)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlayerChatMessageMirror) return false
+
+        if (link != other.link) return false
+        if (!signature.contentEquals(other.signature)) return false
+        if (signedBody != other.signedBody) return false
+        if (unsignedContent != other.unsignedContent) return false
+        if (filterMask != other.filterMask) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = link.hashCode()
+        result = 31 * result + (signature?.contentHashCode() ?: 0)
+        result = 31 * result + signedBody.hashCode()
+        result = 31 * result + (unsignedContent?.hashCode() ?: 0)
+        result = 31 * result + filterMask.hashCode()
+        return result
+    }
+}


### PR DESCRIPTION
This pull request makes significant improvements to the `.github/git-commit-instructions.md` documentation, focusing on clarifying and strengthening the rules for generating Conventional Commit messages. The changes emphasize strict adherence to the specification, provide a detailed decision tree for commit type selection, and improve formatting for readability and precision.

**Major documentation improvements:**

* Added a critical instruction to ignore existing commit history when generating commit messages and to determine the commit type solely from the nature of the code changes in the diff.
* Introduced a comprehensive "Type Decision Guide" and decision tree to standardize how commit types are chosen, including explicit rules for `.api` files and common misclassifications to avoid.
* Improved formatting throughout the document for better readability, including breaking up long lines, clarifying when to use scopes, and providing clearer bullet points and tables. [[1]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7R3-R59) [[2]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L45-R76) [[3]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L78-R110) [[4]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L88-R122) [[5]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L167-R311) [[6]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L185-R336) [[7]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L261-R408) [[8]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L290-R438) [[9]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L333-R486)
* Expanded and clarified the type reference table, including more detailed descriptions and examples for each commit type, and added `abi` as a scope for `.api` file changes.
* Added explicit instructions and examples for handling dependency updates, lockfile changes, and additional context in commit messages. [[1]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L333-R486) [[2]](diffhunk://#diff-aa2aa5f59a70809070f8ba8cca67460eb66a33f567a9dcfed8ba55ee6d9212b7L290-R438)

These changes make the commit message guidelines more robust, objective, and easier to follow, reducing ambiguity and ensuring higher quality commit history.