### PR TITLE
Add PAPER_RAW chat type support and refactor chat index method

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.8.0
+version=3.9.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
@@ -35,8 +35,8 @@ public final class NmsReflections {
         return (FutureChain) serverGamePacketListenerImpl$chatMessageChain.get(instance);
     }
 
-    public static int increaseAndGetNextChatIndex(ServerGamePacketListenerImpl instance) {
-        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1) + 1;
+    public static int getAndIncreaseNextChatIndex(ServerGamePacketListenerImpl instance) {
+        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1);
     }
 
     public static MessageSignatureCache getMessageSignatureCache(ServerGamePacketListenerImpl instance) {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/java/dev/slne/surf/api/paper/server/nms/v1_21_11/reflection/NmsReflections.java
@@ -1,8 +1,11 @@
 package dev.slne.surf.api.paper.server.nms.v1_21_11.reflection;
 
+import io.papermc.paper.adventure.ChatProcessor;
+import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.FilterMask;
 import net.minecraft.network.chat.LastSeenMessagesValidator;
 import net.minecraft.network.chat.MessageSignatureCache;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.util.FutureChain;
 import org.jspecify.annotations.NullMarked;
@@ -23,6 +26,7 @@ public final class NmsReflections {
     private static final VarHandle serverGamePacketListenerImpl$nextChatIndex;
     private static final VarHandle serverGamePacketListenerImpl$messageSignatureCache;
     private static final VarHandle serverGamePacketListenerImpl$lastSeenMessages;
+    private static final VarHandle chatProcessor$PAPER_RAW;
 
     private static final MethodHandle filterMask$mask;
     private static final MethodHandle filterMask$constructorBitSet;
@@ -51,11 +55,17 @@ public final class NmsReflections {
         return (BitSet) filterMask$mask.invokeExact(filterMask);
     }
 
+    @SuppressWarnings("unchecked")
+    public static ResourceKey<ChatType> getPaperRaw() {
+        return (ResourceKey<ChatType>) chatProcessor$PAPER_RAW.get();
+    }
+
     static {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         try {
             MethodHandles.Lookup privateLookupInServerGamePacketListener = MethodHandles.privateLookupIn(ServerGamePacketListenerImpl.class, lookup);
             MethodHandles.Lookup privateLookupInFilterMask = MethodHandles.privateLookupIn(FilterMask.class, lookup);
+            MethodHandles.Lookup privateLookupInChatProcessor = MethodHandles.privateLookupIn(ChatProcessor.class, lookup);
 
             serverGamePacketListenerImpl$chatMessageChain = privateLookupInServerGamePacketListener.findVarHandle(
                     ServerGamePacketListenerImpl.class,
@@ -90,6 +100,12 @@ public final class NmsReflections {
             filterMask$constructorBitSet = privateLookupInFilterMask.findConstructor(
                     FilterMask.class,
                     MethodType.methodType(void.class, BitSet.class)
+            );
+
+            chatProcessor$PAPER_RAW = privateLookupInChatProcessor.findStaticVarHandle(
+                    ChatProcessor.class,
+                    "PAPER_RAW",
+                    ResourceKey.class
             );
         } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException e) {
             throw new ExceptionInInitializerError(e);

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -81,7 +81,7 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     @Suppress("USELESS_ELVIS")
     override fun increaseNextChatIndex(player: Player): Int? {
         val connection = player.toNms().connection ?: return null
-        return NmsReflections.increaseAndGetNextChatIndex(connection)
+        return NmsReflections.getAndIncreaseNextChatIndex(connection)
     }
 
     override fun createPlayerChatMessageMirrorFromAdventure(
@@ -155,7 +155,7 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
         synchronized(messageSignatureCache) {
             connection.send(
                 ClientboundPlayerChatPacket(
-                    NmsReflections.increaseAndGetNextChatIndex(connection),
+                    NmsReflections.getAndIncreaseNextChatIndex(connection),
                     nmsMessage.link().sender(),
                     nmsMessage.link().index(),
                     nmsMessage.signature(),

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -177,4 +177,8 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             }
         }
     }
+
+    override fun getPaperRawChatType(): ChatType {
+        return ChatType.chatType(PaperAdventure.asAdventureKey(NmsReflections.getPaperRaw()))
+    }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
@@ -35,8 +35,8 @@ public final class NmsReflections {
         return (FutureChain) serverGamePacketListenerImpl$chatMessageChain.get(instance);
     }
 
-    public static int increaseAndGetNextChatIndex(ServerGamePacketListenerImpl instance) {
-        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1) + 1;
+    public static int getAndIncreaseNextChatIndex(ServerGamePacketListenerImpl instance) {
+        return (int) serverGamePacketListenerImpl$nextChatIndex.getAndAdd(instance, 1);
     }
 
     public static MessageSignatureCache getMessageSignatureCache(ServerGamePacketListenerImpl instance) {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/java/dev/slne/surf/api/paper/server/nms/v26_1/reflection/NmsReflections.java
@@ -1,8 +1,11 @@
 package dev.slne.surf.api.paper.server.nms.v26_1.reflection;
 
+import io.papermc.paper.adventure.ChatProcessor;
+import net.minecraft.network.chat.ChatType;
 import net.minecraft.network.chat.FilterMask;
 import net.minecraft.network.chat.LastSeenMessagesValidator;
 import net.minecraft.network.chat.MessageSignatureCache;
+import net.minecraft.resources.ResourceKey;
 import net.minecraft.server.network.ServerGamePacketListenerImpl;
 import net.minecraft.util.FutureChain;
 import org.jspecify.annotations.NullMarked;
@@ -23,6 +26,7 @@ public final class NmsReflections {
     private static final VarHandle serverGamePacketListenerImpl$nextChatIndex;
     private static final VarHandle serverGamePacketListenerImpl$messageSignatureCache;
     private static final VarHandle serverGamePacketListenerImpl$lastSeenMessages;
+    private static final VarHandle chatProcessor$PAPER_RAW;
 
     private static final MethodHandle filterMask$mask;
     private static final MethodHandle filterMask$constructorBitSet;
@@ -51,11 +55,17 @@ public final class NmsReflections {
         return (BitSet) filterMask$mask.invokeExact(filterMask);
     }
 
+    @SuppressWarnings("unchecked")
+    public static ResourceKey<ChatType> getPaperRaw() {
+        return (ResourceKey<ChatType>) chatProcessor$PAPER_RAW.get();
+    }
+
     static {
         MethodHandles.Lookup lookup = MethodHandles.lookup();
         try {
             MethodHandles.Lookup privateLookupInServerGamePacketListener = MethodHandles.privateLookupIn(ServerGamePacketListenerImpl.class, lookup);
             MethodHandles.Lookup privateLookupInFilterMask = MethodHandles.privateLookupIn(FilterMask.class, lookup);
+            MethodHandles.Lookup privateLookupInChatProcessor = MethodHandles.privateLookupIn(ChatProcessor.class, lookup);
 
             serverGamePacketListenerImpl$chatMessageChain = privateLookupInServerGamePacketListener.findVarHandle(
                     ServerGamePacketListenerImpl.class,
@@ -90,6 +100,12 @@ public final class NmsReflections {
             filterMask$constructorBitSet = privateLookupInFilterMask.findConstructor(
                     FilterMask.class,
                     MethodType.methodType(void.class, BitSet.class)
+            );
+
+            chatProcessor$PAPER_RAW = privateLookupInChatProcessor.findStaticVarHandle(
+                    ChatProcessor.class,
+                    "PAPER_RAW",
+                    ResourceKey.class
             );
         } catch (IllegalAccessException | NoSuchFieldException | NoSuchMethodException e) {
             throw new ExceptionInInitializerError(e);

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -80,7 +80,7 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     @Suppress("USELESS_ELVIS")
     override fun increaseNextChatIndex(player: Player): Int? {
         val connection = player.toNms().connection ?: return null
-        return NmsReflections.increaseAndGetNextChatIndex(connection)
+        return NmsReflections.getAndIncreaseNextChatIndex(connection)
     }
 
     override fun createPlayerChatMessageMirrorFromAdventure(
@@ -154,7 +154,7 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
         synchronized(messageSignatureCache) {
             connection.send(
                 ClientboundPlayerChatPacket(
-                    NmsReflections.increaseAndGetNextChatIndex(connection),
+                    NmsReflections.getAndIncreaseNextChatIndex(connection),
                     nmsMessage.link().sender(),
                     nmsMessage.link().index(),
                     nmsMessage.signature(),

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -176,4 +176,8 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             }
         }
     }
+
+    override fun getPaperRawChatType(): ChatType {
+        return ChatType.chatType(PaperAdventure.asAdventureKey(NmsReflections.getPaperRaw()))
+    }
 }

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1713,6 +1713,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public abstract fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public abstract fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
@@ -1724,6 +1725,7 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 	public fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
+	public fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -41,6 +41,8 @@ interface SurfPaperNmsPlayerBridge {
         boundChatType: ChatType.Bound
     )
 
+    fun getPaperRawChatType(): ChatType
+
     companion object : SurfPaperNmsPlayerBridge by playerBridge {
         val INSTANCE get() = playerBridge
     }


### PR DESCRIPTION
This pull request updates the Surf API to version 3.9.0 and introduces improvements to chat type handling and chat index management in the Paper NMS bridges for Minecraft 1.21.11 and 1.26.1. The main changes include adding support for retrieving the "raw" Paper chat type, refactoring the chat index increment logic, and updating the relevant interfaces and implementations.

**Chat type improvements:**

* Added a new method `getPaperRawChatType()` to the `SurfPaperNmsPlayerBridge` interface and its implementations, allowing retrieval of the "raw" chat type via reflection from `ChatProcessor.PAPER_RAW`. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR44-R45) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1716) [[3]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1728) [[4]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R180-R183) [[5]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R179-R182) [[6]](diffhunk://#diff-2ed1d6d9cb0bf39bd7d979917a4962167c1622135a57fbd6055e8c4a889223b7R58-R68) [[7]](diffhunk://#diff-2ed1d6d9cb0bf39bd7d979917a4962167c1622135a57fbd6055e8c4a889223b7R104-R109) [[8]](diffhunk://#diff-f0d8910ef30482acdab90b17f8edf810a2ef0a646a6bbdf032833b11c14f8d68R58-R68) [[9]](diffhunk://#diff-f0d8910ef30482acdab90b17f8edf810a2ef0a646a6bbdf032833b11c14f8d68R104-R109)

**Chat index handling:**

* Refactored the chat index increment method from `increaseAndGetNextChatIndex` to `getAndIncreaseNextChatIndex` to correctly match expected behavior (returns the value before increment). Updated all usages accordingly in both Java and Kotlin bridge implementations. [[1]](diffhunk://#diff-2ed1d6d9cb0bf39bd7d979917a4962167c1622135a57fbd6055e8c4a889223b7L34-R39) [[2]](diffhunk://#diff-f0d8910ef30482acdab90b17f8edf810a2ef0a646a6bbdf032833b11c14f8d68L34-R39) [[3]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4L84-R84) [[4]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4L158-R158) [[5]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6L83-R83) [[6]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6L157-R157)

**Version bump:**

* Bumped the project version in `gradle.properties` from 3.8.0 to 3.9.0.

**Codebase consistency:**

* Updated imports and static initializers in NMS reflection classes to support the new chat type logic and maintain consistency across both 1.21.11 and 1.26.1 versions. [[1]](diffhunk://#diff-2ed1d6d9cb0bf39bd7d979917a4962167c1622135a57fbd6055e8c4a889223b7R3-R8) [[2]](diffhunk://#diff-f0d8910ef30482acdab90b17f8edf810a2ef0a646a6bbdf032833b11c14f8d68R3-R8) [[3]](diffhunk://#diff-2ed1d6d9cb0bf39bd7d979917a4962167c1622135a57fbd6055e8c4a889223b7R29) [[4]](diffhunk://#diff-f0d8910ef30482acdab90b17f8edf810a2ef0a646a6bbdf032833b11c14f8d68R29)

Let me know if you have any questions about the new chat type handling or the chat index logic!