### PR TITLE
Fix chunk snapshots creation and update version to 3.9.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.1
 group=dev.slne.surf.api
-version=3.9.2
+version=3.9.3
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/impl/visualizer/visualizer/SurfVisualizerAreaImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/impl/visualizer/visualizer/SurfVisualizerAreaImpl.kt
@@ -264,10 +264,11 @@ class SurfVisualizerAreaImpl(
         val cx = getXFromChunkKey(chunkKey)
         val cz = getZFromChunkKey(chunkKey)
 
-        val chunk = world.getChunkAtAsync(cx, cz).await()
-        val snapshot = chunk.getChunkSnapshot(true, false, false, false)
-        snapshotCache.put(chunkKey, snapshot)
-        return snapshot
+        return world.getChunkAtAsync(cx, cz).thenApply { chunk ->
+            chunk.getChunkSnapshot(true, false, false, false).also {
+                snapshotCache.put(chunkKey, it)
+            }
+        }.await()
     }
 
     fun onChunkBecameVisible(player: Player, chunk: Chunk) {


### PR DESCRIPTION
This pull request includes a version bump and a minor refactor to how chunk snapshots are handled in the visualizer implementation. The most significant change is an improvement to the caching logic to ensure snapshots are stored at the correct time.

Version update:

* Bumped the project version from `3.9.2` to `3.9.3` in `gradle.properties`.

Chunk snapshot caching improvement:

* Refactored the `getChunkSnapshot` logic in `SurfVisualizerAreaImpl.kt` to cache the snapshot inside the asynchronous callback, ensuring that the snapshot is stored only after it is created.