### PR TITLE
✨ feat(plugin): add support for surf-npc integration in PaperPluginSurf

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 group = groupId
 version = buildString {
-    append("2.0.4")
+    append("2.0.5")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfExtension.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfExtension.kt
@@ -21,6 +21,8 @@ open class PaperPluginSurfExtension @Inject constructor(objects: ObjectFactory) 
     internal val foliaSupported = objects.property<Boolean>().convention(true)
     internal val generateLibraryLoader = objects.property<Boolean>().convention(false)
 
+    internal val installSurfNpc = objects.property<Boolean>().convention(false)
+
     fun mainClass(mainClass: String) {
         this.mainClass.set(mainClass)
         this.mainClass.finalizeValue()
@@ -54,6 +56,11 @@ open class PaperPluginSurfExtension @Inject constructor(objects: ObjectFactory) 
     fun generateLibraryLoader(generateLibraryLoader: Boolean) {
         this.generateLibraryLoader.set(generateLibraryLoader)
         this.generateLibraryLoader.finalizeValue()
+    }
+
+    fun withSurfNpc() {
+        installSurfNpc.set(true)
+        installSurfNpc.finalizeValue()
     }
 
     override fun validate() {

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
@@ -14,6 +14,7 @@ import org.gradle.kotlin.dsl.configure
 import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.invoke
 import org.gradle.kotlin.dsl.withType
+import org.jetbrains.kotlin.gradle.utils.COMPILE_ONLY
 import xyz.jpenilla.runpaper.task.RunServer
 
 internal class PaperPluginSurfPlugin :
@@ -30,6 +31,10 @@ internal class PaperPluginSurfPlugin :
         val generateLoaderTask = generateLibrariesLoaderTask(
             extension.mainClass.get().substringBeforeLast('.')
         )
+
+        if (extension.installSurfNpc.get()) {
+            dependencies.add(COMPILE_ONLY, "dev.slne.surf.npc:surf-npc-api:+")
+        }
 
         configure<PaperPluginDescription> {
             authors = extension.authors.get()
@@ -61,6 +66,10 @@ internal class PaperPluginSurfPlugin :
 
                 if (extension.withSurfRedis.get() && !extension.surfRedisRelocation.isPresent) {
                     registerRequired("surf-redis-paper")
+                }
+
+                if (extension.installSurfNpc.get()) {
+                    registerRequired("surf-npc-paper")
                 }
 
                 extension.serverDependencies.orNull?.execute(this)


### PR DESCRIPTION
- update version to 2.0.5 in build.gradle.kts
- introduce installSurfNpc property in PaperPluginSurfExtension
- add withSurfNpc method to enable surf-npc integration
- conditionally add surf-npc dependencies in PaperPluginSurfPlugin