### PR TITLE
Add offline player inventory editing functionality and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.10.0
+version=3.11.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/dummy/DummyEntityEquipment.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/dummy/DummyEntityEquipment.kt
@@ -1,0 +1,187 @@
+package dev.slne.surf.api.paper.nms.common.dummy
+
+import org.bukkit.entity.Entity
+import org.bukkit.inventory.EntityEquipment
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
+
+abstract class DummyEntityEquipment: EntityEquipment {
+    override fun setItem(slot: EquipmentSlot, item: ItemStack?) {
+        throw NotImplementedError()
+    }
+
+    override fun setItem(
+        slot: EquipmentSlot,
+        item: ItemStack?,
+        silent: Boolean
+    ) {
+        setItem(slot, item)
+    }
+
+    override fun getItem(slot: EquipmentSlot): ItemStack {
+        throw NotImplementedError()
+    }
+
+    override fun getItemInMainHand(): ItemStack {
+        return getItem(EquipmentSlot.HAND)
+    }
+
+    override fun setItemInMainHand(item: ItemStack?) {
+        setItem(EquipmentSlot.HAND, item)
+    }
+
+    override fun setItemInMainHand(item: ItemStack?, silent: Boolean) {
+        setItemInMainHand(item)
+    }
+
+    override fun getItemInOffHand(): ItemStack {
+        return getItem(EquipmentSlot.OFF_HAND)
+    }
+
+    override fun setItemInOffHand(item: ItemStack?) {
+        setItem(EquipmentSlot.OFF_HAND, item)
+    }
+
+    override fun setItemInOffHand(item: ItemStack?, silent: Boolean) {
+        setItemInOffHand(item)
+    }
+
+    override fun getItemInHand(): ItemStack {
+        return itemInMainHand
+    }
+
+    override fun setItemInHand(stack: ItemStack?) {
+        setItemInMainHand(stack)
+    }
+
+    override fun getHelmet(): ItemStack {
+        return getItem(EquipmentSlot.HEAD)
+    }
+
+    override fun setHelmet(helmet: ItemStack?) {
+        setItem(EquipmentSlot.HEAD, helmet)
+    }
+
+    override fun setHelmet(helmet: ItemStack?, silent: Boolean) {
+        setHelmet(helmet)
+    }
+
+    override fun getChestplate(): ItemStack {
+        return getItem(EquipmentSlot.CHEST)
+    }
+
+    override fun setChestplate(chestplate: ItemStack?) {
+        setItem(EquipmentSlot.CHEST, chestplate)
+    }
+
+    override fun setChestplate(chestplate: ItemStack?, silent: Boolean) {
+        setChestplate(chestplate)
+    }
+
+    override fun getLeggings(): ItemStack {
+        return getItem(EquipmentSlot.LEGS)
+    }
+
+    override fun setLeggings(leggings: ItemStack?) {
+        setItem(EquipmentSlot.LEGS, leggings)
+    }
+
+    override fun setLeggings(leggings: ItemStack?, silent: Boolean) {
+        setLeggings(leggings)
+    }
+
+    override fun getBoots(): ItemStack {
+        return getItem(EquipmentSlot.FEET)
+    }
+
+    override fun setBoots(boots: ItemStack?) {
+        setItem(EquipmentSlot.FEET, boots)
+    }
+
+    override fun setBoots(boots: ItemStack?, silent: Boolean) {
+        setBoots(boots)
+    }
+
+    override fun getArmorContents(): Array<out ItemStack?> {
+        return arrayOf(boots, leggings, chestplate, helmet)
+    }
+
+    override fun setArmorContents(items: Array<out ItemStack>) {
+        setBoots(items.getOrNull(0))
+        setLeggings(items.getOrNull(1))
+        setChestplate(items.getOrNull(2))
+        setHelmet(items.getOrNull(3))
+    }
+
+    override fun clear() {
+        throw NotImplementedError()
+    }
+
+    override fun getItemInHandDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setItemInHandDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getItemInMainHandDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setItemInMainHandDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getItemInOffHandDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setItemInOffHandDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getHelmetDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setHelmetDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getChestplateDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setChestplateDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getLeggingsDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setLeggingsDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getBootsDropChance(): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setBootsDropChance(chance: Float) {
+        throw NotImplementedError()
+    }
+
+    override fun getHolder(): Entity {
+        throw NotImplementedError()
+    }
+
+    override fun getDropChance(slot: EquipmentSlot): Float {
+        throw NotImplementedError()
+    }
+
+    override fun setDropChance(slot: EquipmentSlot, chance: Float) {
+        throw NotImplementedError()
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -1,5 +1,9 @@
 package dev.slne.surf.api.paper.server.nms.v1_21_11.bridges
 
+import com.destroystokyo.paper.profile.CraftPlayerProfile
+import com.destroystokyo.paper.profile.PlayerProfile
+import dev.slne.surf.api.paper.command.util.idOrThrow
+import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.PlayerInventoryEdit
@@ -36,7 +40,6 @@ import net.minecraft.world.level.storage.TagValueInput
 import net.minecraft.world.level.storage.TagValueOutput
 import net.minecraft.world.level.storage.ValueInput
 import net.minecraft.world.level.storage.ValueOutput
-import org.bukkit.OfflinePlayer
 import org.bukkit.craftbukkit.CraftEquipmentSlot
 import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
@@ -212,13 +215,15 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     override suspend fun editOfflineInventory(
-        player: OfflinePlayer,
+        profile: PlayerProfile,
         edit: (PlayerInventoryEdit) -> Unit
     ) {
-        require(!player.isOnline) { "Player must be offline" }
+        val uuid = profile.idOrThrow()
+        require(server.getPlayer(uuid) == null) { "Player must be offline" }
+        require(profile is CraftPlayerProfile) { "Only CraftPlayerProfile (paper) is supported" }
 
         val server = MinecraftServer.getServer()
-        val nameAndId = NameAndId(player.uniqueId, player.name ?: "#Unknown")
+        val nameAndId = NameAndId(profile.gameProfileUnsafe)
         val rootPathElement = ProblemReporter.PathElement { "OfflinePlayer Inventory[$nameAndId]" }
         val currentTag = loadPlayerTag(server, nameAndId)
         val inventoryEdit = buildInventoryEdit(server, rootPathElement, currentTag)

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -297,6 +297,7 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             }
         } catch (e: Exception) {
             OFFLINE_INVENTORY_EDIT_LOGGER.error("Failed to save offline player inventory", e)
+            throw e
         }
     }
 

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -2,21 +2,50 @@ package dev.slne.surf.api.paper.server.nms.v1_21_11.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
+import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.PlayerInventoryEdit
 import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
+import dev.slne.surf.api.paper.nms.common.dummy.DummyEntityEquipment
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toNms
 import dev.slne.surf.api.paper.server.nms.v1_21_11.reflection.NmsReflections
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import net.minecraft.core.NonNullList
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.NbtIo
 import net.minecraft.network.chat.*
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.players.NameAndId
+import net.minecraft.util.ProblemReporter
+import net.minecraft.util.ProblemReporter.ScopedCollector
+import net.minecraft.util.Util
+import net.minecraft.world.ItemStackWithSlot
+import net.minecraft.world.entity.EntityEquipment
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.npc.InventoryCarrier
+import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.level.storage.TagValueInput
+import net.minecraft.world.level.storage.TagValueOutput
+import net.minecraft.world.level.storage.ValueInput
+import net.minecraft.world.level.storage.ValueOutput
+import org.bukkit.OfflinePlayer
+import org.bukkit.craftbukkit.CraftEquipmentSlot
+import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
 import java.util.*
 import java.util.concurrent.CompletableFuture
+import kotlin.io.path.createTempFile
+import kotlin.jvm.optionals.getOrNull
 
 @NmsUseWithCaution
 class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
@@ -180,5 +209,130 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
     override fun getPaperRawChatType(): ChatType {
         return ChatType.chatType(PaperAdventure.asAdventureKey(NmsReflections.getPaperRaw()))
+    }
+
+    override suspend fun editOfflineInventory(
+        player: OfflinePlayer,
+        edit: (PlayerInventoryEdit) -> Unit
+    ) {
+        require(!player.isOnline) { "Player must be offline" }
+
+        val server = MinecraftServer.getServer()
+        val nameAndId = NameAndId(player.uniqueId, player.name ?: "#Unknown")
+        val rootPathElement = ProblemReporter.PathElement { "OfflinePlayer Inventory[$nameAndId]" }
+        val currentTag = loadPlayerTag(server, nameAndId)
+        val inventoryEdit = buildInventoryEdit(server, rootPathElement, currentTag)
+
+        edit(inventoryEdit)
+        saveInventoryEdit(server, rootPathElement, currentTag, nameAndId, inventoryEdit)
+    }
+
+    private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {
+        val dataStorage = server.playerDataStorage
+        return withContext(Dispatchers.IO) {
+            dataStorage.load(nameAndId).getOrNull() ?: CompoundTag()
+        }
+    }
+
+    private fun buildInventoryEdit(
+        server: MinecraftServer,
+        root: ProblemReporter.PathElement,
+        currentTag: CompoundTag
+    ): PlayerInventoryEdit = ScopedCollector(root, OFFLINE_INVENTORY_EDIT_LOGGER).use { reporter ->
+        val input = TagValueInput.create(reporter, server.registryAccess(), currentTag)
+        val items = loadItems(input.listOrEmpty(InventoryCarrier.TAG_INVENTORY, ItemStackWithSlot.CODEC))
+        val nmsEquipment = input.read(LivingEntity.TAG_EQUIPMENT, EntityEquipment.CODEC).getOrNull()
+            ?: EntityEquipment()
+
+        PlayerInventoryEdit(items, EntityEquipmentMirror(nmsEquipment))
+    }
+
+    private suspend fun saveInventoryEdit(
+        server: MinecraftServer,
+        root: ProblemReporter.PathElement,
+        currentTag: CompoundTag,
+        nameAndId: NameAndId,
+        inventoryEdit: PlayerInventoryEdit
+    ) {
+        ScopedCollector(root, OFFLINE_INVENTORY_EDIT_LOGGER).use { reporter ->
+            val output = TagValueOutput.createWrappingWithContext(reporter, server.registryAccess(), currentTag)
+            saveItems(
+                inventoryEdit.items,
+                output.list(InventoryCarrier.TAG_INVENTORY, ItemStackWithSlot.CODEC)
+            )
+
+            val nmsEquipment = (inventoryEdit.equipment as EntityEquipmentMirror).equipment
+            if (!nmsEquipment.isEmpty) {
+                output.store(LivingEntity.TAG_EQUIPMENT, EntityEquipment.CODEC, nmsEquipment)
+            } else {
+                output.discard(LivingEntity.TAG_EQUIPMENT)
+            }
+
+            writePlayerTag(server, nameAndId, output.buildResult())
+        }
+    }
+
+    private suspend fun writePlayerTag(
+        server: MinecraftServer,
+        nameAndId: NameAndId,
+        rootTag: CompoundTag
+    ) {
+        try {
+            val playerDirPath = server.playerDataStorage.playerDir.toPath()
+            val playerId = nameAndId.id.toString()
+            val tmp = createTempFile(playerDirPath, "$playerId-", ".dat")
+
+            withContext(Dispatchers.IO) {
+                NbtIo.writeCompressed(rootTag, tmp)
+                Util.safeReplaceFile(
+                    playerDirPath.resolve("$playerId.dat"),
+                    tmp,
+                    playerDirPath.resolve("${playerId}.dat_old")
+                )
+            }
+        } catch (e: Exception) {
+            OFFLINE_INVENTORY_EDIT_LOGGER.error("Failed to save offline player inventory", e)
+        }
+    }
+
+    private fun loadItems(input: ValueInput.TypedInputList<ItemStackWithSlot>): MutableList<ItemStack> {
+        val items = NonNullList.withSize(Inventory.INVENTORY_SIZE, ItemStack.empty())
+
+        for (item in input) {
+            if (item.isValidInContainer(items.size)) {
+                items[item.slot()] = item.stack().asBukkitMirror()
+            }
+        }
+
+        return items
+    }
+
+    private fun saveItems(items: List<ItemStack>, output: ValueOutput.TypedOutputList<ItemStackWithSlot>) {
+        for ((index, stack) in items.withIndex()) {
+            if (!stack.isEmpty) {
+                output.add(ItemStackWithSlot(index, stack.toNms()))
+            }
+        }
+    }
+
+    private class EntityEquipmentMirror(val equipment: EntityEquipment) : DummyEntityEquipment() {
+        override fun setItem(slot: EquipmentSlot, item: ItemStack?) {
+            val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+            val nmsStack = CraftItemStack.asNMSCopy(item)
+            equipment.set(nmsSlot, nmsStack)
+        }
+
+        override fun getItem(slot: EquipmentSlot): ItemStack {
+            val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+            return equipment.get(nmsSlot).asBukkitMirror()
+        }
+
+        override fun clear() {
+            equipment.clear()
+        }
+    }
+
+    companion object {
+        private val OFFLINE_INVENTORY_EDIT_LOGGER = ComponentLogger.logger("OfflinePlayer Inventory Edit")
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -2,20 +2,49 @@ package dev.slne.surf.api.paper.server.nms.v26_1.bridges
 
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
+import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.PlayerInventoryEdit
 import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
+import dev.slne.surf.api.paper.nms.common.dummy.DummyEntityEquipment
 import dev.slne.surf.api.paper.server.nms.v26_1.extensions.toNms
 import dev.slne.surf.api.paper.server.nms.v26_1.reflection.NmsReflections
 import io.papermc.paper.adventure.PaperAdventure
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
+import net.kyori.adventure.text.logger.slf4j.ComponentLogger
+import net.minecraft.core.NonNullList
+import net.minecraft.nbt.CompoundTag
+import net.minecraft.nbt.NbtIo
 import net.minecraft.network.chat.*
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket
+import net.minecraft.server.MinecraftServer
+import net.minecraft.server.players.NameAndId
+import net.minecraft.util.ProblemReporter
+import net.minecraft.util.ProblemReporter.ScopedCollector
+import net.minecraft.util.Util
+import net.minecraft.world.ItemStackWithSlot
+import net.minecraft.world.entity.EntityEquipment
+import net.minecraft.world.entity.LivingEntity
+import net.minecraft.world.entity.npc.InventoryCarrier
+import net.minecraft.world.entity.player.Inventory
+import net.minecraft.world.level.storage.TagValueInput
+import net.minecraft.world.level.storage.TagValueOutput
+import net.minecraft.world.level.storage.ValueInput
+import net.minecraft.world.level.storage.ValueOutput
+import org.bukkit.OfflinePlayer
+import org.bukkit.craftbukkit.CraftEquipmentSlot
+import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
+import org.bukkit.inventory.EquipmentSlot
+import org.bukkit.inventory.ItemStack
 import java.util.concurrent.CompletableFuture
+import kotlin.io.path.createTempFile
+import kotlin.jvm.optionals.getOrNull
 
 @NmsUseWithCaution
 class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
@@ -179,5 +208,130 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
     override fun getPaperRawChatType(): ChatType {
         return ChatType.chatType(PaperAdventure.asAdventureKey(NmsReflections.getPaperRaw()))
+    }
+
+    override suspend fun editOfflineInventory(
+        player: OfflinePlayer,
+        edit: (PlayerInventoryEdit) -> Unit
+    ) {
+        require(!player.isOnline) { "Player must be offline" }
+
+        val server = MinecraftServer.getServer()
+        val nameAndId = NameAndId(player.uniqueId, player.name ?: "#Unknown")
+        val rootPathElement = ProblemReporter.PathElement { "OfflinePlayer Inventory[$nameAndId]" }
+        val currentTag = loadPlayerTag(server, nameAndId)
+        val inventoryEdit = buildInventoryEdit(server, rootPathElement, currentTag)
+
+        edit(inventoryEdit)
+        saveInventoryEdit(server, rootPathElement, currentTag, nameAndId, inventoryEdit)
+    }
+
+    private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {
+        val dataStorage = server.playerDataStorage
+        return withContext(Dispatchers.IO) {
+            dataStorage.load(nameAndId).getOrNull() ?: CompoundTag()
+        }
+    }
+
+    private fun buildInventoryEdit(
+        server: MinecraftServer,
+        root: ProblemReporter.PathElement,
+        currentTag: CompoundTag
+    ): PlayerInventoryEdit = ScopedCollector(root, OFFLINE_INVENTORY_EDIT_LOGGER).use { reporter ->
+        val input = TagValueInput.create(reporter, server.registryAccess(), currentTag)
+        val items = loadItems(input.listOrEmpty(InventoryCarrier.TAG_INVENTORY, ItemStackWithSlot.CODEC))
+        val nmsEquipment = input.read(LivingEntity.TAG_EQUIPMENT, EntityEquipment.CODEC).getOrNull()
+            ?: EntityEquipment()
+
+        PlayerInventoryEdit(items, EntityEquipmentMirror(nmsEquipment))
+    }
+
+    private suspend fun saveInventoryEdit(
+        server: MinecraftServer,
+        root: ProblemReporter.PathElement,
+        currentTag: CompoundTag,
+        nameAndId: NameAndId,
+        inventoryEdit: PlayerInventoryEdit
+    ) {
+        ScopedCollector(root, OFFLINE_INVENTORY_EDIT_LOGGER).use { reporter ->
+            val output = TagValueOutput.createWrappingWithContext(reporter, server.registryAccess(), currentTag)
+            saveItems(
+                inventoryEdit.items,
+                output.list(InventoryCarrier.TAG_INVENTORY, ItemStackWithSlot.CODEC)
+            )
+
+            val nmsEquipment = (inventoryEdit.equipment as EntityEquipmentMirror).equipment
+            if (!nmsEquipment.isEmpty) {
+                output.store(LivingEntity.TAG_EQUIPMENT, EntityEquipment.CODEC, nmsEquipment)
+            } else {
+                output.discard(LivingEntity.TAG_EQUIPMENT)
+            }
+
+            writePlayerTag(server, nameAndId, output.buildResult())
+        }
+    }
+
+    private suspend fun writePlayerTag(
+        server: MinecraftServer,
+        nameAndId: NameAndId,
+        rootTag: CompoundTag
+    ) {
+        try {
+            val playerDirPath = server.playerDataStorage.playerDir.toPath()
+            val playerId = nameAndId.id.toString()
+            val tmp = createTempFile(playerDirPath, "$playerId-", ".dat")
+
+            withContext(Dispatchers.IO) {
+                NbtIo.writeCompressed(rootTag, tmp)
+                Util.safeReplaceFile(
+                    playerDirPath.resolve("$playerId.dat"),
+                    tmp,
+                    playerDirPath.resolve("${playerId}.dat_old")
+                )
+            }
+        } catch (e: Exception) {
+            OFFLINE_INVENTORY_EDIT_LOGGER.error("Failed to save offline player inventory", e)
+        }
+    }
+
+    private fun loadItems(input: ValueInput.TypedInputList<ItemStackWithSlot>): MutableList<ItemStack> {
+        val items = NonNullList.withSize(Inventory.INVENTORY_SIZE, ItemStack.empty())
+
+        for (item in input) {
+            if (item.isValidInContainer(items.size)) {
+                items[item.slot()] = item.stack().asBukkitMirror()
+            }
+        }
+
+        return items
+    }
+
+    private fun saveItems(items: List<ItemStack>, output: ValueOutput.TypedOutputList<ItemStackWithSlot>) {
+        for ((index, stack) in items.withIndex()) {
+            if (!stack.isEmpty) {
+                output.add(ItemStackWithSlot(index, stack.toNms()))
+            }
+        }
+    }
+
+    private class EntityEquipmentMirror(val equipment: EntityEquipment) : DummyEntityEquipment() {
+        override fun setItem(slot: EquipmentSlot, item: ItemStack?) {
+            val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+            val nmsStack = CraftItemStack.asNMSCopy(item)
+            equipment.set(nmsSlot, nmsStack)
+        }
+
+        override fun getItem(slot: EquipmentSlot): ItemStack {
+            val nmsSlot = CraftEquipmentSlot.getNMS(slot)
+            return equipment.get(nmsSlot).asBukkitMirror()
+        }
+
+        override fun clear() {
+            equipment.clear()
+        }
+    }
+
+    companion object {
+        private val OFFLINE_INVENTORY_EDIT_LOGGER = ComponentLogger.logger("OfflinePlayer Inventory Edit")
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -296,6 +296,7 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             }
         } catch (e: Exception) {
             OFFLINE_INVENTORY_EDIT_LOGGER.error("Failed to save offline player inventory", e)
+            throw e
         }
     }
 

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -1,5 +1,9 @@
 package dev.slne.surf.api.paper.server.nms.v26_1.bridges
 
+import com.destroystokyo.paper.profile.CraftPlayerProfile
+import com.destroystokyo.paper.profile.PlayerProfile
+import dev.slne.surf.api.paper.command.util.idOrThrow
+import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.PlayerInventoryEdit
@@ -36,7 +40,6 @@ import net.minecraft.world.level.storage.TagValueInput
 import net.minecraft.world.level.storage.TagValueOutput
 import net.minecraft.world.level.storage.ValueInput
 import net.minecraft.world.level.storage.ValueOutput
-import org.bukkit.OfflinePlayer
 import org.bukkit.craftbukkit.CraftEquipmentSlot
 import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
@@ -211,13 +214,15 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     override suspend fun editOfflineInventory(
-        player: OfflinePlayer,
+        profile: PlayerProfile,
         edit: (PlayerInventoryEdit) -> Unit
     ) {
-        require(!player.isOnline) { "Player must be offline" }
+        val uuid = profile.idOrThrow()
+        require(server.getPlayer(uuid) == null) { "Player must be offline" }
+        require(profile is CraftPlayerProfile) { "Only CraftPlayerProfile (paper) is supported" }
 
         val server = MinecraftServer.getServer()
-        val nameAndId = NameAndId(player.uniqueId, player.name ?: "#Unknown")
+        val nameAndId = NameAndId(profile.gameProfileUnsafe)
         val rootPathElement = ProblemReporter.PathElement { "OfflinePlayer Inventory[$nameAndId]" }
         val currentTag = loadPlayerTag(server, nameAndId)
         val inventoryEdit = buildInventoryEdit(server, rootPathElement, currentTag)

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
@@ -31,7 +31,8 @@ public class SurfApiTestCommand extends CommandAPICommand {
                 new ShowItemCommand("showitem"),
                 new SortInvCommand("sortInv"),
                 new SignedMessageArgumentTest("signedmessage"),
-                new BlockPdcContainerTest("blockpdc")
+                new BlockPdcContainerTest("blockpdc"),
+                new OfflineInventoryEditTest("editOfflineInventory")
         );
     }
 }

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/args/EquipmentSlotArgument.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/args/EquipmentSlotArgument.kt
@@ -1,0 +1,26 @@
+package dev.slne.surf.surfapi.bukkit.test.command.args
+
+import dev.jorel.commandapi.arguments.ArgumentSuggestions
+import dev.jorel.commandapi.arguments.CustomArgument
+import dev.jorel.commandapi.arguments.StringArgument
+import org.bukkit.inventory.EquipmentSlot
+
+class EquipmentSlotArgument(name: String) :
+    CustomArgument<EquipmentSlot, String>(StringArgument(name), { info ->
+        try {
+            EquipmentSlot.valueOf(info.input)
+        } catch (e: IllegalArgumentException) {
+            throw CustomArgumentException.fromMessageBuilder(
+                MessageBuilder()
+                    .append("Invalid equipment slot: ")
+                    .appendArgInput()
+                    .append(" (valid: ")
+                    .append(EquipmentSlot.entries.joinToString(", ") { it.name })
+                    .append(")")
+            )
+        }
+    }) {
+    init {
+        replaceSuggestions(ArgumentSuggestions.strings(EquipmentSlot.entries.map { it.name }))
+    }
+}

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/OfflineInventoryEditTest.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/OfflineInventoryEditTest.kt
@@ -2,6 +2,7 @@
 
 package dev.slne.surf.surfapi.bukkit.test.command.subcommands
 
+import com.destroystokyo.paper.profile.PlayerProfile
 import dev.jorel.commandapi.CommandAPICommand
 import dev.jorel.commandapi.arguments.AsyncPlayerProfileArgument
 import dev.jorel.commandapi.kotlindsl.argument
@@ -11,14 +12,11 @@ import dev.jorel.commandapi.kotlindsl.subcommand
 import dev.slne.surf.api.paper.command.executors.anyExecutorSuspend
 import dev.slne.surf.api.paper.command.executors.playerExecutorSuspend
 import dev.slne.surf.api.paper.command.util.awaitAsyncPlayerProfile
-import dev.slne.surf.api.paper.command.util.idOrThrow
-import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.surfapi.bukkit.test.command.args.EquipmentSlotArgument
 import org.bukkit.command.CommandSender
 import org.bukkit.inventory.EquipmentSlot
-import java.util.*
 
 class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
     init {
@@ -33,7 +31,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
         integerArgument("slot", 0, 35)
 
         playerExecutorSuspend { sender, args ->
-            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val target = args.awaitAsyncPlayerProfile("player")
             val slot: Int by args
             val item = sender.inventory.itemInMainHand.clone()
 
@@ -46,7 +44,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
                 edit.items[slot] = item
             }) return@playerExecutorSuspend
 
-            sender.sendMessage("Set slot $slot of $target to ${item.type.key.asString()} x${item.amount}.")
+            sender.sendMessage("Set slot $slot of ${target.name} to ${item.type.key.asString()} x${item.amount}.")
         }
     }
 
@@ -55,7 +53,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
         argument(EquipmentSlotArgument("slot"))
 
         playerExecutorSuspend { sender, args ->
-            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val target = args.awaitAsyncPlayerProfile("player")
             val slot: EquipmentSlot by args
             val item = sender.inventory.itemInMainHand.clone()
 
@@ -68,7 +66,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
                 edit.equipment.setItem(slot, item)
             }) return@playerExecutorSuspend
 
-            sender.sendMessage("Set equipment slot ${slot.name} of $target to ${item.type.key.asString()} x${item.amount}.")
+            sender.sendMessage("Set equipment slot ${slot.name} of ${target.name} to ${item.type.key.asString()} x${item.amount}.")
         }
     }
 
@@ -76,7 +74,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
         argument(AsyncPlayerProfileArgument("player"))
 
         anyExecutorSuspend { sender, args ->
-            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val target = args.awaitAsyncPlayerProfile("player")
             var inventoryItems = emptyList<String>()
             var equipmentItems = emptyList<String>()
 
@@ -91,7 +89,7 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
                     .map { (slot, item) -> "${slot.name}=${item.type.key.asString()} x${item.amount}" }
             }) return@anyExecutorSuspend
 
-            sender.sendMessage("Offline inventory summary for ${target}:")
+            sender.sendMessage("Offline inventory summary for ${target.name}:")
             sender.sendMessage("Inventory: ${inventoryItems.ifEmpty { listOf("empty") }.joinToString()}")
             sender.sendMessage("Equipment: ${equipmentItems.ifEmpty { listOf("empty") }.joinToString()}")
         }
@@ -101,24 +99,24 @@ class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
         argument(AsyncPlayerProfileArgument("player"))
 
         anyExecutorSuspend { sender, args ->
-            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val target = args.awaitAsyncPlayerProfile("player")
 
             if (!runEdit(sender, target) { edit ->
                 edit.items.clear()
                 edit.equipment.clear()
             }) return@anyExecutorSuspend
 
-            sender.sendMessage("Cleared offline inventory and equipment of ${target}.")
+            sender.sendMessage("Cleared offline inventory and equipment of ${target.name}.")
         }
     }
 
     private suspend fun runEdit(
         sender: CommandSender,
-        target: UUID,
+        target: PlayerProfile,
         edit: (SurfPaperNmsPlayerBridge.PlayerInventoryEdit) -> Unit
     ): Boolean {
         return runCatching {
-            SurfPaperNmsPlayerBridge.editOfflineInventory(server.getOfflinePlayer(target), edit)
+            SurfPaperNmsPlayerBridge.editOfflineInventory(target, edit)
         }.onFailure { error ->
             sender.sendMessage("editOfflineInventory failed: ${error::class.simpleName}: ${error.message}")
         }.isSuccess

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/OfflineInventoryEditTest.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/OfflineInventoryEditTest.kt
@@ -1,0 +1,137 @@
+@file:OptIn(NmsUseWithCaution::class)
+
+package dev.slne.surf.surfapi.bukkit.test.command.subcommands
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.arguments.AsyncPlayerProfileArgument
+import dev.jorel.commandapi.kotlindsl.argument
+import dev.jorel.commandapi.kotlindsl.getValue
+import dev.jorel.commandapi.kotlindsl.integerArgument
+import dev.jorel.commandapi.kotlindsl.subcommand
+import dev.slne.surf.api.paper.command.executors.anyExecutorSuspend
+import dev.slne.surf.api.paper.command.executors.playerExecutorSuspend
+import dev.slne.surf.api.paper.command.util.awaitAsyncPlayerProfile
+import dev.slne.surf.api.paper.command.util.idOrThrow
+import dev.slne.surf.api.paper.extensions.server
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
+import dev.slne.surf.surfapi.bukkit.test.command.args.EquipmentSlotArgument
+import org.bukkit.command.CommandSender
+import org.bukkit.inventory.EquipmentSlot
+import java.util.*
+
+class OfflineInventoryEditTest(name: String) : CommandAPICommand(name) {
+    init {
+        setSlotCommand()
+        setEquipmentCommand()
+        summaryCommand()
+        clearCommand()
+    }
+
+    private fun setSlotCommand() = subcommand("set-slot") {
+        argument(AsyncPlayerProfileArgument("player"))
+        integerArgument("slot", 0, 35)
+
+        playerExecutorSuspend { sender, args ->
+            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val slot: Int by args
+            val item = sender.inventory.itemInMainHand.clone()
+
+            if (item.isEmpty) {
+                sender.sendMessage("Hold an item in your main hand to copy it into the offline inventory.")
+                return@playerExecutorSuspend
+            }
+
+            if (!runEdit(sender, target) { edit ->
+                edit.items[slot] = item
+            }) return@playerExecutorSuspend
+
+            sender.sendMessage("Set slot $slot of $target to ${item.type.key.asString()} x${item.amount}.")
+        }
+    }
+
+    private fun setEquipmentCommand() = subcommand("set-equipment") {
+        argument(AsyncPlayerProfileArgument("player"))
+        argument(EquipmentSlotArgument("slot"))
+
+        playerExecutorSuspend { sender, args ->
+            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            val slot: EquipmentSlot by args
+            val item = sender.inventory.itemInMainHand.clone()
+
+            if (item.isEmpty) {
+                sender.sendMessage("Hold an item in your main hand to copy it into the offline equipment.")
+                return@playerExecutorSuspend
+            }
+
+            if (!runEdit(sender, target) { edit ->
+                edit.equipment.setItem(slot, item)
+            }) return@playerExecutorSuspend
+
+            sender.sendMessage("Set equipment slot ${slot.name} of $target to ${item.type.key.asString()} x${item.amount}.")
+        }
+    }
+
+    private fun summaryCommand() = subcommand("summary") {
+        argument(AsyncPlayerProfileArgument("player"))
+
+        anyExecutorSuspend { sender, args ->
+            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+            var inventoryItems = emptyList<String>()
+            var equipmentItems = emptyList<String>()
+
+            if (!runEdit(sender, target) { edit ->
+                inventoryItems = edit.items.withIndex()
+                    .filter { (_, item) -> !item.isEmpty }
+                    .map { (slot, item) -> "slot $slot=${item.type.key.asString()} x${item.amount}" }
+
+                equipmentItems = EDITABLE_EQUIPMENT_SLOTS
+                    .map { slot -> slot to edit.equipment.getItem(slot) }
+                    .filter { (_, item) -> !item.isEmpty }
+                    .map { (slot, item) -> "${slot.name}=${item.type.key.asString()} x${item.amount}" }
+            }) return@anyExecutorSuspend
+
+            sender.sendMessage("Offline inventory summary for ${target}:")
+            sender.sendMessage("Inventory: ${inventoryItems.ifEmpty { listOf("empty") }.joinToString()}")
+            sender.sendMessage("Equipment: ${equipmentItems.ifEmpty { listOf("empty") }.joinToString()}")
+        }
+    }
+
+    private fun clearCommand() = subcommand("clear") {
+        argument(AsyncPlayerProfileArgument("player"))
+
+        anyExecutorSuspend { sender, args ->
+            val target = args.awaitAsyncPlayerProfile("player").idOrThrow()
+
+            if (!runEdit(sender, target) { edit ->
+                edit.items.clear()
+                edit.equipment.clear()
+            }) return@anyExecutorSuspend
+
+            sender.sendMessage("Cleared offline inventory and equipment of ${target}.")
+        }
+    }
+
+    private suspend fun runEdit(
+        sender: CommandSender,
+        target: UUID,
+        edit: (SurfPaperNmsPlayerBridge.PlayerInventoryEdit) -> Unit
+    ): Boolean {
+        return runCatching {
+            SurfPaperNmsPlayerBridge.editOfflineInventory(server.getOfflinePlayer(target), edit)
+        }.onFailure { error ->
+            sender.sendMessage("editOfflineInventory failed: ${error::class.simpleName}: ${error.message}")
+        }.isSuccess
+    }
+
+    companion object {
+        private val EDITABLE_EQUIPMENT_SLOTS = listOf(
+            EquipmentSlot.HAND,
+            EquipmentSlot.OFF_HAND,
+            EquipmentSlot.HEAD,
+            EquipmentSlot.CHEST,
+            EquipmentSlot.LEGS,
+            EquipmentSlot.FEET
+        )
+    }
+}

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1713,6 +1713,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public abstract fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public abstract fun editOfflineInventory (Lorg/bukkit/OfflinePlayer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
@@ -1724,6 +1725,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
 	public fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public fun editOfflineInventory (Lorg/bukkit/OfflinePlayer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
 	public fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
@@ -1735,6 +1737,19 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$DefaultImpls {
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$PlayerInventoryEdit {
+	public fun <init> (Ljava/util/List;Lorg/bukkit/inventory/EntityEquipment;)V
+	public final fun component1 ()Ljava/util/List;
+	public final fun component2 ()Lorg/bukkit/inventory/EntityEquipment;
+	public final fun copy (Ljava/util/List;Lorg/bukkit/inventory/EntityEquipment;)Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$PlayerInventoryEdit;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$PlayerInventoryEdit;Ljava/util/List;Lorg/bukkit/inventory/EntityEquipment;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$PlayerInventoryEdit;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getEquipment ()Lorg/bukkit/inventory/EntityEquipment;
+	public final fun getItems ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
 }
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge {

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1713,7 +1713,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public abstract fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
-	public abstract fun editOfflineInventory (Lorg/bukkit/OfflinePlayer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
@@ -1725,7 +1725,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
 	public fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
 	public fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
-	public fun editOfflineInventory (Lorg/bukkit/OfflinePlayer;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
 	public fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -2,13 +2,17 @@ package dev.slne.surf.api.paper.nms.bridges
 
 import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.Companion.editOfflineInventory
 import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import kotlinx.coroutines.CoroutineScope
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
+import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player
+import org.bukkit.inventory.EntityEquipment
+import org.bukkit.inventory.ItemStack
 import org.jetbrains.annotations.ApiStatus
 
 @NmsUseWithCaution
@@ -42,6 +46,35 @@ interface SurfPaperNmsPlayerBridge {
     )
 
     fun getPaperRawChatType(): ChatType
+
+    /**
+     * Loads an offline player's inventory and equipment, exposes them for mutation, and persists
+     * the modified state back to disk.
+     *
+     * The [player] must be offline when this function is called.
+     *
+     * Warning: behavior is undefined, unsafe, and not supported if the player joins while this
+     * operation is running.
+     *
+     * @param player the offline player whose persisted inventory data should be edited
+     * @param edit callback that receives a mutable [PlayerInventoryEdit] snapshot
+     */
+    suspend fun editOfflineInventory(
+        player: OfflinePlayer,
+        edit: (PlayerInventoryEdit) -> Unit
+    )
+
+    /**
+     * Mutable snapshot used by [editOfflineInventory] to modify a player's persisted inventory
+     * and equipment.
+     *
+     * @property items mutable main inventory contents (expected size: 36)
+     * @property equipment mutable equipment view (armor/offhand/main hand)
+     */
+    data class PlayerInventoryEdit(
+        val items: MutableList<ItemStack>,
+        val equipment: EntityEquipment
+    )
 
     companion object : SurfPaperNmsPlayerBridge by playerBridge {
         val INSTANCE get() = playerBridge

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -1,5 +1,6 @@
 package dev.slne.surf.api.paper.nms.bridges
 
+import com.destroystokyo.paper.profile.PlayerProfile
 import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.Companion.editOfflineInventory
@@ -9,7 +10,6 @@ import kotlinx.coroutines.CoroutineScope
 import net.kyori.adventure.chat.ChatType
 import net.kyori.adventure.chat.SignedMessage
 import net.kyori.adventure.text.Component
-import org.bukkit.OfflinePlayer
 import org.bukkit.entity.Player
 import org.bukkit.inventory.EntityEquipment
 import org.bukkit.inventory.ItemStack
@@ -51,16 +51,16 @@ interface SurfPaperNmsPlayerBridge {
      * Loads an offline player's inventory and equipment, exposes them for mutation, and persists
      * the modified state back to disk.
      *
-     * The [player] must be offline when this function is called.
+     * The player of the [profile] must be offline when this function is called.
      *
      * Warning: behavior is undefined, unsafe, and not supported if the player joins while this
      * operation is running.
      *
-     * @param player the offline player whose persisted inventory data should be edited
+     * @param profile the offline player profile whose persisted inventory data should be edited
      * @param edit callback that receives a mutable [PlayerInventoryEdit] snapshot
      */
     suspend fun editOfflineInventory(
-        player: OfflinePlayer,
+        profile: PlayerProfile,
         edit: (PlayerInventoryEdit) -> Unit
     )
 


### PR DESCRIPTION
This pull request introduces a new API for editing offline player inventories and equipment, and implements this functionality for both the 1.21.1 and 1.26.1 NMS bridges. It also adds a `DummyEntityEquipment` abstraction to help with equipment handling and bumps the project version.

**Offline Inventory Editing Feature**

* Added a new suspend function `editOfflineInventory` to the `SurfPaperNmsPlayerBridge` interface, allowing safe editing of offline player inventories and equipment. [[1]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1716) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1728)

* Implemented `editOfflineInventory` for both `V1_21_11SurfPaperNmsPlayerBridgeImpl` and `V26_1SurfPaperNmsPlayerBridgeImpl`, including robust loading, editing, and saving of inventory and equipment data for offline players, with error handling and logging. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R213-R337) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R212-R336)

**Equipment Abstraction**

* Introduced the `DummyEntityEquipment` abstract class to provide a common base for equipment manipulation, and used it to implement an `EntityEquipmentMirror` for offline inventory editing. [[1]](diffhunk://#diff-9a3cd5045ba7403b0df36305ed538fe91dd1501546dd3964d22c1a9fb016e954R1-R187) [[2]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R213-R337) [[3]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R212-R336)

**Versioning**

* Bumped the project version from `3.10.0` to `3.11.0` in `gradle.properties` to reflect the new feature addition.