### PR TITLE
Update dependency versions in libs.versions.toml and gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.11.0
+version=3.11.1
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,15 +1,15 @@
 [versions]
 # Paper
 paper-api = "26.1+"
-canvas-api = "1.21.11-R0.1-SNAPSHOT"
+canvas-api = "26.1+"
 
 # Kolin
-kotlinVersion = "2.3.20"
-kotlinxCoroutines = "1.10.2"
+kotlinVersion = "2.3.21"
+kotlinxCoroutines = "1.11.0"
 kotlinx-serialization = "1.11.0"
 
 # Packet Events
-packetevents = "2.11.2"
+packetevents = "2.12.1"
 packetevents-plugin = "2.12.1"
 
 # Command API
@@ -35,9 +35,9 @@ placeholder-api = "2.12.2"
 mccoroutine = "2.22.2"
 
 # Miscellaneous Libraries
-guava = "33.5.0-jre"
-caffeine = "3.2.3"
-caffeine-courotines = "3.0.2"
+guava = "33.6.0-jre"
+caffeine = "3.2.4"
+caffeine-courotines = "3.0.4"
 gson = "2.13.2"
 commons-lang3 = "3.20.0"
 commons-text = "1.15.0"
@@ -58,10 +58,10 @@ flogger = "0.9"
 aide-reflection = "1.3"
 auto-service = "1.1.1"
 auto-service-ksp = "1.2.0"
-ktor = "3.4.2"
+ktor = "3.4.3"
 glm = "0.9.9.1-15"
-ksp-version = "2.3.6"
-reactor-netty = "1.3.4"
+ksp-version = "2.3.7"
+reactor-netty = "1.3.5"
 bytebuddy = "1.18.8"
 
 # Plugin versions


### PR DESCRIPTION
This pull request updates several dependencies and plugin versions to their latest releases and bumps the project version. These changes help keep the project up-to-date with upstream improvements and bug fixes.

Dependency version updates:

* Updated multiple library versions in `gradle/libs.versions.toml`, including `canvas-api`, `kotlinVersion`, `kotlinxCoroutines`, `packetevents`, `guava`, `caffeine`, `caffeine-courotines`, `ktor`, `ksp-version`, and `reactor-netty` to their latest versions. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R12) [[2]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL38-R40) [[3]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL61-R64)

Project version bump:

* Increased the project version from `3.11.0` to `3.11.1` in `gradle.properties`.