### PR TITLE
Add getPlayerDataDir method for player data retrieval

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.13.0
+version=3.14.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -45,6 +45,7 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
+import java.io.File
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.createTempFile
@@ -230,6 +231,10 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
         edit(inventoryEdit)
         saveInventoryEdit(server, rootPathElement, currentTag, nameAndId, inventoryEdit)
+    }
+
+    override fun getPlayerDataDir(): File {
+        return MinecraftServer.getServer().playerDataStorage.playerDir
     }
 
     private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -45,6 +45,7 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
+import java.io.File
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.createTempFile
 import kotlin.jvm.optionals.getOrNull
@@ -229,6 +230,10 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
         edit(inventoryEdit)
         saveInventoryEdit(server, rootPathElement, currentTag, nameAndId, inventoryEdit)
+    }
+
+    override fun getPlayerDataDir(): File {
+       return MinecraftServer.getServer().playerDataStorage.playerDir
     }
 
     private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1715,6 +1715,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public abstract fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
+	public abstract fun getPlayerDataDir ()Ljava/io/File;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
@@ -1728,6 +1729,7 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 	public fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
 	public fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
+	public fun getPlayerDataDir ()Ljava/io/File;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -14,6 +14,7 @@ import org.bukkit.entity.Player
 import org.bukkit.inventory.EntityEquipment
 import org.bukkit.inventory.ItemStack
 import org.jetbrains.annotations.ApiStatus
+import java.io.File
 
 @NmsUseWithCaution
 @ApiStatus.NonExtendable
@@ -75,6 +76,13 @@ interface SurfPaperNmsPlayerBridge {
         val items: MutableList<ItemStack>,
         val equipment: EntityEquipment
     )
+
+    /**
+     * Retrieves the directory where player data is stored.
+     *
+     * @return a [File] representing the directory used for storing player data
+     */
+    fun getPlayerDataDir(): File
 
     companion object : SurfPaperNmsPlayerBridge by playerBridge {
         val INSTANCE get() = playerBridge


### PR DESCRIPTION
This pull request introduces a new API method to retrieve the player data directory, implements it for both supported Minecraft versions, and increments the project version. These changes enhance the ability to access player data files directly from the API, improving extensibility for plugins or tools that need to interact with player data storage.

**API Additions:**

* Added the abstract method `getPlayerDataDir(): File` to the `SurfPaperNmsPlayerBridge` interface, allowing retrieval of the directory where player data is stored. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR80-R86) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1718)

**Implementation Updates:**

* Implemented the `getPlayerDataDir` method in both `V1_21_11SurfPaperNmsPlayerBridgeImpl` and `V26_1SurfPaperNmsPlayerBridgeImpl`, returning the appropriate player data directory from the server. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R236-R239) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R235-R238)

**Versioning:**

* Bumped the project version from `3.13.0` to `3.14.0` in `gradle.properties` to reflect the new API addition.