### PR TITLE
Add getStatsDataPath method for statistical data retrieval

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.14.0
+version=3.15.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -36,16 +36,14 @@ import net.minecraft.world.entity.EntityEquipment
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.npc.InventoryCarrier
 import net.minecraft.world.entity.player.Inventory
-import net.minecraft.world.level.storage.TagValueInput
-import net.minecraft.world.level.storage.TagValueOutput
-import net.minecraft.world.level.storage.ValueInput
-import net.minecraft.world.level.storage.ValueOutput
+import net.minecraft.world.level.storage.*
 import org.bukkit.craftbukkit.CraftEquipmentSlot
 import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
 import java.io.File
+import java.nio.file.Path
 import java.util.*
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.createTempFile
@@ -235,6 +233,10 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
     override fun getPlayerDataDir(): File {
         return MinecraftServer.getServer().playerDataStorage.playerDir
+    }
+
+    override fun getStatsDataPath(): Path {
+        return MinecraftServer.getServer().getWorldPath(LevelResource.PLAYER_STATS_DIR)
     }
 
     private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -36,16 +36,14 @@ import net.minecraft.world.entity.EntityEquipment
 import net.minecraft.world.entity.LivingEntity
 import net.minecraft.world.entity.npc.InventoryCarrier
 import net.minecraft.world.entity.player.Inventory
-import net.minecraft.world.level.storage.TagValueInput
-import net.minecraft.world.level.storage.TagValueOutput
-import net.minecraft.world.level.storage.ValueInput
-import net.minecraft.world.level.storage.ValueOutput
+import net.minecraft.world.level.storage.*
 import org.bukkit.craftbukkit.CraftEquipmentSlot
 import org.bukkit.craftbukkit.inventory.CraftItemStack
 import org.bukkit.entity.Player
 import org.bukkit.inventory.EquipmentSlot
 import org.bukkit.inventory.ItemStack
 import java.io.File
+import java.nio.file.Path
 import java.util.concurrent.CompletableFuture
 import kotlin.io.path.createTempFile
 import kotlin.jvm.optionals.getOrNull
@@ -233,7 +231,11 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     override fun getPlayerDataDir(): File {
-       return MinecraftServer.getServer().playerDataStorage.playerDir
+        return MinecraftServer.getServer().playerDataStorage.playerDir
+    }
+
+    override fun getStatsDataPath(): Path {
+        return MinecraftServer.getServer().getWorldPath(LevelResource.PLAYER_STATS_DIR)
     }
 
     private suspend fun loadPlayerTag(server: MinecraftServer, nameAndId: NameAndId): CompoundTag {

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1717,6 +1717,7 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public abstract fun getPlayerDataDir ()Ljava/io/File;
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public abstract fun getStatsDataPath ()Ljava/nio/file/Path;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
@@ -1731,6 +1732,7 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 	public fun getPaperRawChatType ()Lnet/kyori/adventure/chat/ChatType;
 	public fun getPlayerDataDir ()Ljava/io/File;
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public fun getStatsDataPath ()Ljava/nio/file/Path;
 	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -15,6 +15,7 @@ import org.bukkit.inventory.EntityEquipment
 import org.bukkit.inventory.ItemStack
 import org.jetbrains.annotations.ApiStatus
 import java.io.File
+import java.nio.file.Path
 
 @NmsUseWithCaution
 @ApiStatus.NonExtendable
@@ -83,6 +84,13 @@ interface SurfPaperNmsPlayerBridge {
      * @return a [File] representing the directory used for storing player data
      */
     fun getPlayerDataDir(): File
+
+    /**
+     * Retrieves the file system path used for storing statistical data.
+     *
+     * @return a [Path] object representing the location where statistical data is stored
+     */
+    fun getStatsDataPath(): Path
 
     companion object : SurfPaperNmsPlayerBridge by playerBridge {
         val INSTANCE get() = playerBridge


### PR DESCRIPTION
This pull request introduces a new API method for retrieving the path to the player statistics data directory and implements it for both the 1.21.11 and 26.1 NMS bridges. It also bumps the project version to 3.15.0. The changes ensure that the statistics data path can be accessed in a type-safe way across supported Minecraft versions.

### API Additions

* Added a new method `getStatsDataPath(): Path` to the `SurfPaperNmsPlayerBridge` interface and its API signatures, allowing retrieval of the stats data directory as a `Path` object. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR88-R94) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1720) [[3]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1735)

### Implementation Updates

* Implemented the `getStatsDataPath()` method in both `V1_21_11SurfPaperNmsPlayerBridgeImpl` and `V26_1SurfPaperNmsPlayerBridgeImpl`, using `MinecraftServer.getServer().getWorldPath(LevelResource.PLAYER_STATS_DIR)` to obtain the correct path. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R238-R241) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R237-R240)

### Dependency and Import Maintenance

* Updated imports in the bridge implementation files to include `java.nio.file.Path` and simplify storage-related imports. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4L39-R46) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6L39-R46) [[3]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR18)

### Versioning

* Bumped the project version from 3.14.0 to 3.15.0 in `gradle.properties` to reflect the new API addition.