### PR TITLE
Implement suspend command requirements and optimize packet handling

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.15.0
+version=3.16.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
@@ -1,0 +1,8 @@
+package dev.slne.surf.api.paper.nms.common
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.packet.listener.listener.PacketListener
+import java.util.*
+
+@OptIn(NmsUseWithCaution::class)
+abstract class CommandSendPacketBlockerListener(protected val blockedPlayer: Set<UUID>) : PacketListener

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
@@ -3,6 +3,13 @@ package dev.slne.surf.api.paper.nms.common
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.packet.listener.listener.PacketListener
 import java.util.*
+import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(NmsUseWithCaution::class)
-abstract class CommandSendPacketBlockerListener(protected val blockedPlayer: Set<UUID>) : PacketListener
+abstract class CommandSendPacketBlockerListener(protected val blockedPlayer: Set<UUID>) : PacketListener {
+    protected val receivedCommandPacket: MutableSet<UUID> = ConcurrentHashMap.newKeySet<UUID>()
+
+    fun removeReceivedCommandPacket(uuid: UUID) {
+        receivedCommandPacket.remove(uuid)
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
@@ -7,9 +7,9 @@ import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(NmsUseWithCaution::class)
 abstract class CommandSendPacketBlockerListener(protected val blockedPlayers: Set<UUID>) : PacketListener {
-    protected val receivedCommandPacket: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
+    protected val receivedFirstCommandPacket: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
-    fun removeReceivedCommandPacket(uuid: UUID) {
-        receivedCommandPacket.remove(uuid)
+    fun removeReceivedFirstCommandPacket(uuid: UUID) {
+        receivedFirstCommandPacket.remove(uuid)
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/CommandSendPacketBlockerListener.kt
@@ -6,8 +6,8 @@ import java.util.*
 import java.util.concurrent.ConcurrentHashMap
 
 @OptIn(NmsUseWithCaution::class)
-abstract class CommandSendPacketBlockerListener(protected val blockedPlayer: Set<UUID>) : PacketListener {
-    protected val receivedCommandPacket: MutableSet<UUID> = ConcurrentHashMap.newKeySet<UUID>()
+abstract class CommandSendPacketBlockerListener(protected val blockedPlayers: Set<UUID>) : PacketListener {
+    protected val receivedCommandPacket: MutableSet<UUID> = ConcurrentHashMap.newKeySet()
 
     fun removeReceivedCommandPacket(uuid: UUID) {
         receivedCommandPacket.remove(uuid)

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/NmsProvider.kt
@@ -85,7 +85,7 @@ interface NmsProvider {
     fun createChannelInjector(): AbstractChannelInjector<*>
     fun createPacketListenerApi(): InternalPacketListenerApiBridge
 
-    fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener
+    fun createCommandSendPacketBlockerListener(blockedPlayers: Set<UUID>): CommandSendPacketBlockerListener
 
     /**
      * Creates version-specific packet listeners (e.g. lore handler, glowing handler).

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-common/src/main/kotlin/dev/slne/surf/api/paper/nms/common/NmsProvider.kt
@@ -18,6 +18,7 @@ import dev.slne.surf.api.shared.internal.nms.NmsVersion
 import org.bukkit.plugin.java.JavaPlugin
 import java.io.File
 import java.net.URI
+import java.util.*
 import java.util.jar.JarFile
 
 /**
@@ -83,6 +84,8 @@ interface NmsProvider {
 
     fun createChannelInjector(): AbstractChannelInjector<*>
     fun createPacketListenerApi(): InternalPacketListenerApiBridge
+
+    fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener
 
     /**
      * Creates version-specific packet listeners (e.g. lore handler, glowing handler).

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
@@ -22,6 +22,7 @@ import dev.slne.surf.api.paper.server.nms.v1_21_11.bridges.packets.player.V1_21_
 import dev.slne.surf.api.paper.server.nms.v1_21_11.glow.V1_21_11GlowingLifecycleHandler
 import dev.slne.surf.api.paper.server.nms.v1_21_11.glow.V1_21_11SurfGlowingApiImpl
 import dev.slne.surf.api.paper.server.nms.v1_21_11.packet.listener.V1_21_11ChannelInjector
+import dev.slne.surf.api.paper.server.nms.v1_21_11.packet.listener.V1_21_11CommandSendPacketBlockerListenerImpl
 import dev.slne.surf.api.paper.server.nms.v1_21_11.packet.listener.V1_21_11GlowingPacketListener
 import dev.slne.surf.api.paper.server.nms.v1_21_11.packet.lore.V1_21_11PacketLoreListener
 import dev.slne.surf.api.paper.server.nms.v1_21_11.packet.lore.V1_21_11PacketLoreRegistry
@@ -30,6 +31,7 @@ import dev.slne.surf.api.paper.server.nms.v1_21_11.region.V1_21_11TickThreadGuar
 import dev.slne.surf.api.shared.internal.nms.NmsProviderMarker
 import dev.slne.surf.api.shared.internal.nms.NmsVersion
 import org.bukkit.plugin.java.JavaPlugin
+import java.util.*
 
 @Suppress("ClassName")
 @OptIn(NmsUseWithCaution::class)
@@ -88,6 +90,10 @@ class V1_21_11NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
     override fun createGlowingApi(): SurfGlowingApi = V1_21_11SurfGlowingApiImpl
     override fun createChannelInjector(): AbstractChannelInjector<*> = V1_21_11ChannelInjector
     override fun createPacketListenerApi(): InternalPacketListenerApiBridge = V1_21_11PacketListenerApiImpl()
+
+    override fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener {
+        return V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer)
+    }
 
     override fun createPacketListeners(): List<PacketListener> = listOf(
         V1_21_11PacketLoreListener,

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/V1_21_11NmsProvider.kt
@@ -91,8 +91,8 @@ class V1_21_11NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
     override fun createChannelInjector(): AbstractChannelInjector<*> = V1_21_11ChannelInjector
     override fun createPacketListenerApi(): InternalPacketListenerApiBridge = V1_21_11PacketListenerApiImpl()
 
-    override fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener {
-        return V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer)
+    override fun createCommandSendPacketBlockerListener(blockedPlayers: Set<UUID>): CommandSendPacketBlockerListener {
+        return V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayers)
     }
 
     override fun createPacketListeners(): List<PacketListener> = listOf(

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
@@ -43,7 +43,7 @@ class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayers: Set<UUID>) :
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
         if (blockedPlayers.contains(player.uuid)) {
-            return if (receivedCommandPacket.add(player.uuid)) {
+            return if (receivedFirstCommandPacket.add(player.uuid)) {
                 ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
             } else {
                 null

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
@@ -1,0 +1,23 @@
+package dev.slne.surf.api.paper.server.nms.v1_21_11.packet.listener
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.common.CommandSendPacketBlockerListener
+import dev.slne.surf.api.paper.packet.listener.listener.annotation.ClientboundListener
+import net.minecraft.network.protocol.game.ClientboundCommandsPacket
+import net.minecraft.server.level.ServerPlayer
+import java.util.*
+
+@OptIn(NmsUseWithCaution::class)
+@Suppress("ClassName")
+class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
+    CommandSendPacketBlockerListener(blockedPlayer) {
+
+    @ClientboundListener
+    fun onClientboundCommandsPacket(
+        packet: ClientboundCommandsPacket,
+        player: ServerPlayer
+    ): ClientboundCommandsPacket? {
+        if (blockedPlayer.contains(player.uuid)) return null
+        return packet
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
@@ -1,9 +1,15 @@
 package dev.slne.surf.api.paper.server.nms.v1_21_11.packet.listener
 
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.tree.ArgumentCommandNode
+import com.mojang.brigadier.tree.CommandNode
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.common.CommandSendPacketBlockerListener
 import dev.slne.surf.api.paper.packet.listener.listener.annotation.ClientboundListener
+import net.minecraft.commands.CommandSourceStack
 import net.minecraft.network.protocol.game.ClientboundCommandsPacket
+import net.minecraft.resources.Identifier
 import net.minecraft.server.level.ServerPlayer
 import java.util.*
 
@@ -12,12 +18,38 @@ import java.util.*
 class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
     CommandSendPacketBlockerListener(blockedPlayer) {
 
+    private val loadingCommandsDispatcher = CommandDispatcher<CommandSourceStack>()
+    private val commandNodeInspector = object : ClientboundCommandsPacket.NodeInspector<CommandSourceStack> {
+        override fun suggestionId(p0: ArgumentCommandNode<CommandSourceStack, *>): Identifier? {
+            return null
+        }
+
+        override fun isExecutable(p0: CommandNode<CommandSourceStack>): Boolean {
+            return false
+        }
+
+        override fun isRestricted(p0: CommandNode<CommandSourceStack>): Boolean {
+            return false
+        }
+    }
+
+    init {
+        loadingCommandsDispatcher.register(LiteralArgumentBuilder.literal("commands-are-loading"))
+    }
+
     @ClientboundListener
     fun onClientboundCommandsPacket(
         packet: ClientboundCommandsPacket,
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
-        if (blockedPlayer.contains(player.uuid)) return null
+        if (blockedPlayer.contains(player.uuid)) {
+            return if (receivedCommandPacket.add(player.uuid)) {
+                ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
+            } else {
+                null
+            }
+        }
+
         return packet
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/packet/listener/V1_21_11CommandSendPacketBlockerListenerImpl.kt
@@ -15,8 +15,8 @@ import java.util.*
 
 @OptIn(NmsUseWithCaution::class)
 @Suppress("ClassName")
-class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
-    CommandSendPacketBlockerListener(blockedPlayer) {
+class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayers: Set<UUID>) :
+    CommandSendPacketBlockerListener(blockedPlayers) {
 
     private val loadingCommandsDispatcher = CommandDispatcher<CommandSourceStack>()
     private val commandNodeInspector = object : ClientboundCommandsPacket.NodeInspector<CommandSourceStack> {
@@ -42,7 +42,7 @@ class V1_21_11CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
         packet: ClientboundCommandsPacket,
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
-        if (blockedPlayer.contains(player.uuid)) {
+        if (blockedPlayers.contains(player.uuid)) {
             return if (receivedCommandPacket.add(player.uuid)) {
                 ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
             } else {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
@@ -22,6 +22,7 @@ import dev.slne.surf.api.paper.server.nms.v26_1.bridges.packets.player.V26_1Surf
 import dev.slne.surf.api.paper.server.nms.v26_1.glow.V26_1GlowingLifecycleHandler
 import dev.slne.surf.api.paper.server.nms.v26_1.glow.V26_1SurfGlowingApiImpl
 import dev.slne.surf.api.paper.server.nms.v26_1.packet.listener.V26_1ChannelInjector
+import dev.slne.surf.api.paper.server.nms.v26_1.packet.listener.V26_1CommandSendPacketBlockerListenerImpl
 import dev.slne.surf.api.paper.server.nms.v26_1.packet.listener.V26_1GlowingPacketListener
 import dev.slne.surf.api.paper.server.nms.v26_1.packet.lore.V26_1PacketLoreListener
 import dev.slne.surf.api.paper.server.nms.v26_1.packet.lore.V26_1PacketLoreRegistry
@@ -30,6 +31,7 @@ import dev.slne.surf.api.paper.server.nms.v26_1.region.V26_1TickThreadGuard
 import dev.slne.surf.api.shared.internal.nms.NmsProviderMarker
 import dev.slne.surf.api.shared.internal.nms.NmsVersion
 import org.bukkit.plugin.java.JavaPlugin
+import java.util.*
 
 @Suppress("ClassName")
 @OptIn(NmsUseWithCaution::class)
@@ -67,6 +69,10 @@ class V26_1NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
     override fun createGlowingApi(): SurfGlowingApi = V26_1SurfGlowingApiImpl
     override fun createChannelInjector(): AbstractChannelInjector<*> = V26_1ChannelInjector
     override fun createPacketListenerApi(): InternalPacketListenerApiBridge = V26_1PacketListenerApiImpl()
+
+    override fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener {
+        return V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer)
+    }
 
     override fun createPacketListeners(): List<PacketListener> = listOf(
         V26_1PacketLoreListener,

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/V26_1NmsProvider.kt
@@ -70,8 +70,8 @@ class V26_1NmsProvider(override val plugin: JavaPlugin) : NmsProvider {
     override fun createChannelInjector(): AbstractChannelInjector<*> = V26_1ChannelInjector
     override fun createPacketListenerApi(): InternalPacketListenerApiBridge = V26_1PacketListenerApiImpl()
 
-    override fun createCommandSendPacketBlockerListener(blockedPlayer: Set<UUID>): CommandSendPacketBlockerListener {
-        return V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer)
+    override fun createCommandSendPacketBlockerListener(blockedPlayers: Set<UUID>): CommandSendPacketBlockerListener {
+        return V26_1CommandSendPacketBlockerListenerImpl(blockedPlayers)
     }
 
     override fun createPacketListeners(): List<PacketListener> = listOf(

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
@@ -1,9 +1,15 @@
 package dev.slne.surf.api.paper.server.nms.v26_1.packet.listener
 
+import com.mojang.brigadier.CommandDispatcher
+import com.mojang.brigadier.builder.LiteralArgumentBuilder
+import com.mojang.brigadier.tree.ArgumentCommandNode
+import com.mojang.brigadier.tree.CommandNode
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.common.CommandSendPacketBlockerListener
 import dev.slne.surf.api.paper.packet.listener.listener.annotation.ClientboundListener
+import net.minecraft.commands.CommandSourceStack
 import net.minecraft.network.protocol.game.ClientboundCommandsPacket
+import net.minecraft.resources.Identifier
 import net.minecraft.server.level.ServerPlayer
 import java.util.*
 
@@ -13,12 +19,38 @@ import java.util.*
 class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
     CommandSendPacketBlockerListener(blockedPlayer) {
 
+    private val loadingCommandsDispatcher = CommandDispatcher<CommandSourceStack>()
+    private val commandNodeInspector = object : ClientboundCommandsPacket.NodeInspector<CommandSourceStack> {
+        override fun suggestionId(p0: ArgumentCommandNode<CommandSourceStack, *>): Identifier? {
+            return null
+        }
+
+        override fun isExecutable(p0: CommandNode<CommandSourceStack>): Boolean {
+            return false
+        }
+
+        override fun isRestricted(p0: CommandNode<CommandSourceStack>): Boolean {
+            return false
+        }
+    }
+
+    init {
+        loadingCommandsDispatcher.register(LiteralArgumentBuilder.literal("commands-are-loading"))
+    }
+
     @ClientboundListener
     fun onClientboundCommandsPacket(
         packet: ClientboundCommandsPacket,
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
-        if (blockedPlayer.contains(player.uuid)) return null
+        if (blockedPlayer.contains(player.uuid)) {
+            return if (receivedCommandPacket.add(player.uuid)) {
+                ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
+            } else {
+                null
+            }
+        }
+
         return packet
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
@@ -1,0 +1,24 @@
+package dev.slne.surf.api.paper.server.nms.v26_1.packet.listener
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.common.CommandSendPacketBlockerListener
+import dev.slne.surf.api.paper.packet.listener.listener.annotation.ClientboundListener
+import net.minecraft.network.protocol.game.ClientboundCommandsPacket
+import net.minecraft.server.level.ServerPlayer
+import java.util.*
+
+
+@Suppress("ClassName")
+@OptIn(NmsUseWithCaution::class)
+class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
+    CommandSendPacketBlockerListener(blockedPlayer) {
+
+    @ClientboundListener
+    fun onClientboundCommandsPacket(
+        packet: ClientboundCommandsPacket,
+        player: ServerPlayer
+    ): ClientboundCommandsPacket? {
+        if (blockedPlayer.contains(player.uuid)) return null
+        return packet
+    }
+}

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
@@ -44,7 +44,7 @@ class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayers: Set<UUID>) :
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
         if (blockedPlayers.contains(player.uuid)) {
-            return if (receivedCommandPacket.add(player.uuid)) {
+            return if (receivedFirstCommandPacket.add(player.uuid)) {
                 ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
             } else {
                 null

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/packet/listener/V26_1CommandSendPacketBlockerListenerImpl.kt
@@ -16,8 +16,8 @@ import java.util.*
 
 @Suppress("ClassName")
 @OptIn(NmsUseWithCaution::class)
-class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
-    CommandSendPacketBlockerListener(blockedPlayer) {
+class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayers: Set<UUID>) :
+    CommandSendPacketBlockerListener(blockedPlayers) {
 
     private val loadingCommandsDispatcher = CommandDispatcher<CommandSourceStack>()
     private val commandNodeInspector = object : ClientboundCommandsPacket.NodeInspector<CommandSourceStack> {
@@ -43,7 +43,7 @@ class V26_1CommandSendPacketBlockerListenerImpl(blockedPlayer: Set<UUID>) :
         packet: ClientboundCommandsPacket,
         player: ServerPlayer
     ): ClientboundCommandsPacket? {
-        if (blockedPlayer.contains(player.uuid)) {
+        if (blockedPlayers.contains(player.uuid)) {
             return if (receivedCommandPacket.add(player.uuid)) {
                 ClientboundCommandsPacket(loadingCommandsDispatcher.root, commandNodeInspector)
             } else {

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/java/dev/slne/surf/api/paper/test/command/SurfApiTestCommand.java
@@ -33,7 +33,8 @@ public class SurfApiTestCommand extends CommandAPICommand {
                 new SignedMessageArgumentTest("signedmessage"),
                 new BlockPdcContainerTest("blockpdc"),
                 new OfflineInventoryEditTest("editOfflineInventory"),
-                new ModernSerializerTestConfigCommand("modernSerializerTestConfig")
+                new ModernSerializerTestConfigCommand("modernSerializerTestConfig"),
+                new SuspendRequirementTestCommand("suspendRequirement")
         );
     }
 }

--- a/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SuspendRequirementTestCommand.kt
+++ b/surf-api-paper/surf-api-paper-plugin-test/src/main/kotlin/dev/slne/surf/surfapi/bukkit/test/command/subcommands/SuspendRequirementTestCommand.kt
@@ -1,0 +1,45 @@
+package dev.slne.surf.surfapi.bukkit.test.command.subcommands
+
+import dev.jorel.commandapi.CommandAPICommand
+import dev.jorel.commandapi.kotlindsl.*
+import dev.slne.surf.api.paper.command.requirement.withSuspendPlayerRequirement
+import kotlinx.coroutines.delay
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.time.Duration.Companion.seconds
+
+class SuspendRequirementTestCommand(name: String) : CommandAPICommand(name) {
+    private val shown = ConcurrentHashMap.newKeySet<UUID>()
+
+    init {
+        subcommand("updateCommands") {
+            playerExecutor { player, _ ->
+                player.updateCommands()
+            }
+        }
+
+        subcommand("showCommand") {
+            booleanArgument("show")
+
+            playerExecutor { player, arguments ->
+                val show: Boolean by arguments
+                if (show) {
+                    shown.add(player.uniqueId)
+                } else {
+                    shown.remove(player.uniqueId)
+                }
+            }
+        }
+
+        subcommand("conditionalCommand") {
+            withSuspendPlayerRequirement { player ->
+                delay(10.seconds)
+                player.uniqueId in shown
+            }
+
+            anyExecutor { sender, _ ->
+                sender.sendMessage("This command is only available to players who have shown it")
+            }
+        }
+    }
+}

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -113,9 +113,9 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
 
                 if (ready.remove(uuid)) {
                     blockedCommandPackets.remove(uuid)
-                    triggerRefreshForSender(event.player)
                 } else {
                     blockedCommandPackets.add(uuid)
+                    triggerRefreshForSender(event.player)
                 }
             }
         }

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -114,8 +114,9 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
                 if (ready.remove(uuid)) {
                     blockedCommandPackets.remove(uuid)
                 } else {
-                    blockedCommandPackets.add(uuid)
-                    triggerRefreshForSender(event.player)
+                    if (blockedCommandPackets.add(uuid)) {
+                        triggerRefreshForSender(event.player)
+                    }
                 }
             }
         }

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -151,7 +151,10 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
         suspend fun refreshForSender(sender: Player) {
             withContext(scope().coroutineContext.minusKey(Job)) {
                 try {
-                    cached.put(sender.uniqueId, requirement(sender))
+                    val isRequirementMet = requirement(sender)
+                    if (sender.isConnected) { // check if this player instance is still connected
+                        cached.put(sender.uniqueId, isRequirementMet)
+                    }
                 } catch (e: Throwable) {
                     if (e is CancellationException) throw e
                     log.atWarning()

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -1,0 +1,155 @@
+package dev.slne.surf.api.paper.server.command
+
+import com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent
+import com.destroystokyo.paper.event.player.PlayerConnectionCloseEvent
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.shynixn.mccoroutine.folia.launch
+import com.google.auto.service.AutoService
+import dev.jorel.commandapi.ExecutableCommand
+import dev.slne.surf.api.core.util.checkInstantiationByServiceLoader
+import dev.slne.surf.api.core.util.logger
+import dev.slne.surf.api.paper.command.executors.CoroutineScopeProvider
+import dev.slne.surf.api.paper.command.requirement.SuspendRequirementService
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import dev.slne.surf.api.paper.nms.common.CommandSendPacketBlockerListener
+import dev.slne.surf.api.paper.nms.common.NmsProvider
+import dev.slne.surf.api.paper.server.plugin
+import io.papermc.paper.command.brigadier.CommandSourceStack
+import kotlinx.coroutines.*
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.Listener
+import java.util.*
+import java.util.concurrent.ConcurrentHashMap
+import kotlin.coroutines.cancellation.CancellationException
+
+@AutoService(SuspendRequirementService::class)
+class SuspendRequirementServiceImpl : SuspendRequirementService {
+    init {
+        checkInstantiationByServiceLoader()
+    }
+
+    companion object {
+        private val log = logger()
+
+        fun get() = SuspendRequirementService.instance as SuspendRequirementServiceImpl
+    }
+
+    private val requirements = Caffeine.newBuilder()
+        .build<UUID, Requirement>()
+
+    private val blockedCommandPackets = ConcurrentHashMap.newKeySet<UUID>()
+    private val ready = ConcurrentHashMap.newKeySet<UUID>()
+
+    private val listener = EventListener()
+
+    @OptIn(NmsUseWithCaution::class)
+    fun createCommandSendPacketBlockerListener(): CommandSendPacketBlockerListener {
+        return NmsProvider.current.createCommandSendPacketBlockerListener(blockedCommandPackets)
+    }
+
+    fun getEventListener(): Listener {
+        return listener
+    }
+
+    override fun <Impl : ExecutableCommand<Impl, CommandSender>> ExecutableCommand<Impl, CommandSender>.withSuspendRequirement(
+        scope: CoroutineScopeProvider,
+        requirement: suspend CoroutineScope.(Player) -> Boolean,
+        allowIfNonPlayer: Boolean
+    ) {
+        val id = UUID.randomUUID()
+        register(id, scope, requirement)
+        withRequirement {
+            if (it !is Player) {
+                allowIfNonPlayer
+            } else {
+                testCached(id, it)
+            }
+        }
+    }
+
+    private fun register(
+        id: UUID,
+        scope: CoroutineScopeProvider,
+        requirement: suspend CoroutineScope.(Player) -> Boolean
+    ) {
+        requirements.put(id, Requirement(scope, requirement))
+    }
+
+    private fun testCached(id: UUID, sender: Player): Boolean {
+        val requirement = requirements.getIfPresent(id) ?: return false
+        return requirement.testCached(sender)
+    }
+
+    suspend fun refreshForSender(sender: Player) {
+        coroutineScope {
+            for (requirement in requirements.asMap().values) {
+                launch {
+                    requirement.refreshForSender(sender)
+                }
+            }
+        }
+
+        ready.add(sender.uniqueId)
+        sender.updateCommands()
+    }
+
+    fun triggerRefreshForSender(sender: Player) {
+        plugin.launch {
+            refreshForSender(sender)
+        }
+    }
+
+    inner class EventListener : Listener {
+
+        @EventHandler
+        @Suppress("UnstableApiUsage")
+        fun onAsyncPlayerSendCommand(event: AsyncPlayerSendCommandsEvent<CommandSourceStack>) {
+            if (requirements.asMap().isEmpty()) return
+
+            if (event.isAsynchronous || !event.hasFiredAsync()) {
+                val uuid = event.player.uniqueId
+
+                if (ready.remove(uuid)) {
+                    blockedCommandPackets.remove(uuid)
+                    triggerRefreshForSender(event.player)
+                } else {
+                    blockedCommandPackets.add(uuid)
+                }
+            }
+        }
+
+        @EventHandler
+        fun onConnectionClosed(event: PlayerConnectionCloseEvent) {
+            blockedCommandPackets.remove(event.playerUniqueId)
+            ready.remove(event.playerUniqueId)
+        }
+    }
+
+    data class Requirement(
+        val scope: CoroutineScopeProvider,
+        val requirement: suspend CoroutineScope.(Player) -> Boolean
+    ) {
+        private val cached = Caffeine.newBuilder()
+            .weakKeys()
+            .build<UUID, Boolean>()
+
+        fun testCached(sender: Player): Boolean {
+            return cached.getIfPresent(sender.uniqueId) ?: false
+        }
+
+        suspend fun refreshForSender(sender: Player) {
+            withContext(scope().coroutineContext.minusKey(Job)) {
+                try {
+                    cached.put(sender.uniqueId, requirement(sender))
+                } catch (e: Throwable) {
+                    if (e is CancellationException) throw e
+                    log.atWarning()
+                        .withCause(e)
+                        .log("Failed to check requirement for sender $sender! Not updating cache.")
+                }
+            }
+        }
+    }
+}

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -45,8 +45,11 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
     private val listener = EventListener()
 
     @OptIn(NmsUseWithCaution::class)
-    fun createCommandSendPacketBlockerListener(): CommandSendPacketBlockerListener {
-        return NmsProvider.current.createCommandSendPacketBlockerListener(blockedCommandPackets)
+    private val commandSendPacketBlockerListener =
+        NmsProvider.current.createCommandSendPacketBlockerListener(blockedCommandPackets)
+
+    fun getCommandSendPacketBlockerListener(): CommandSendPacketBlockerListener {
+        return commandSendPacketBlockerListener
     }
 
     fun getEventListener(): Listener {
@@ -125,6 +128,7 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
         fun onConnectionClosed(event: PlayerConnectionCloseEvent) {
             blockedCommandPackets.remove(event.playerUniqueId)
             ready.remove(event.playerUniqueId)
+            commandSendPacketBlockerListener.removeReceivedCommandPacket(event.playerUniqueId)
         }
     }
 

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -129,6 +129,7 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
             blockedCommandPackets.remove(event.playerUniqueId)
             ready.remove(event.playerUniqueId)
             commandSendPacketBlockerListener.removeReceivedCommandPacket(event.playerUniqueId)
+            requirements.asMap().values.forEach { it.invalidate(event.playerUniqueId) }
         }
     }
 
@@ -137,11 +138,14 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
         val requirement: suspend CoroutineScope.(Player) -> Boolean
     ) {
         private val cached = Caffeine.newBuilder()
-            .weakKeys()
             .build<UUID, Boolean>()
 
         fun testCached(sender: Player): Boolean {
             return cached.getIfPresent(sender.uniqueId) ?: false
+        }
+
+        fun invalidate(uuid: UUID) {
+            cached.invalidate(uuid)
         }
 
         suspend fun refreshForSender(sender: Player) {

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/command/SuspendRequirementServiceImpl.kt
@@ -128,7 +128,7 @@ class SuspendRequirementServiceImpl : SuspendRequirementService {
         fun onConnectionClosed(event: PlayerConnectionCloseEvent) {
             blockedCommandPackets.remove(event.playerUniqueId)
             ready.remove(event.playerUniqueId)
-            commandSendPacketBlockerListener.removeReceivedCommandPacket(event.playerUniqueId)
+            commandSendPacketBlockerListener.removeReceivedFirstCommandPacket(event.playerUniqueId)
             requirements.asMap().values.forEach { it.invalidate(event.playerUniqueId) }
         }
     }

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/listener/ListenerManager.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/listener/ListenerManager.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.api.paper.server.listener
 
 import dev.slne.surf.api.paper.event.register
+import dev.slne.surf.api.paper.server.command.SuspendRequirementServiceImpl
 import dev.slne.surf.api.paper.server.impl.glow.GlowingListener
 import dev.slne.surf.api.paper.server.impl.pdc.block.BlockDataListener
 import dev.slne.surf.api.paper.server.impl.visualizer.visualizer.VisualizerListener
@@ -17,6 +18,8 @@ object ListenerManager {
         GlowingListener.register()
 
         BlockDataListener.register()
+
+        SuspendRequirementServiceImpl.get().getEventListener().register()
     }
 
     /**

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
@@ -52,6 +52,8 @@ object PacketApiLoader {
         }
         versionPacketListeners = emptyList()
 
+        SurfPaperPacketListenerApi.unregisterListeners(SuspendRequirementServiceImpl.get().getCommandSendPacketBlockerListener())
+
         PluginDisablePacketLoreListener.unregister()
         AbstractChannelInjector.instance.unregister()
         provider.shutdown()

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
@@ -36,7 +36,7 @@ object PacketApiLoader {
             SurfPaperPacketListenerApi.registerListeners(listener)
         }
 
-        SurfPaperPacketListenerApi.registerListeners(SuspendRequirementServiceImpl.get().createCommandSendPacketBlockerListener())
+        SurfPaperPacketListenerApi.registerListeners(SuspendRequirementServiceImpl.get().getCommandSendPacketBlockerListener())
 
         AbstractChannelInjector.instance.register()
         PluginDisablePacketLoreListener.register()

--- a/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
+++ b/surf-api-paper/surf-api-paper-server/src/main/kotlin/dev/slne/surf/api/paper/server/packet/PacketApiLoader.kt
@@ -9,6 +9,7 @@ import dev.slne.surf.api.paper.nms.common.AbstractChannelInjector
 import dev.slne.surf.api.paper.nms.common.NmsProvider
 import dev.slne.surf.api.paper.packet.listener.SurfPaperPacketListenerApi
 import dev.slne.surf.api.paper.packet.listener.listener.PacketListener
+import dev.slne.surf.api.paper.server.command.SuspendRequirementServiceImpl
 import dev.slne.surf.api.paper.server.packet.lore.PluginDisablePacketLoreListener
 import dev.slne.surf.api.paper.server.plugin
 import io.github.retrooper.packetevents.factory.spigot.SpigotPacketEventsBuilder
@@ -34,6 +35,8 @@ object PacketApiLoader {
         for (listener in versionPacketListeners) {
             SurfPaperPacketListenerApi.registerListeners(listener)
         }
+
+        SurfPaperPacketListenerApi.registerListeners(SuspendRequirementServiceImpl.get().createCommandSendPacketBlockerListener())
 
         AbstractChannelInjector.instance.register()
         PluginDisablePacketLoreListener.register()

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -227,6 +227,20 @@ public final class dev/slne/surf/api/paper/command/executors/SuspendCommandExecu
 	public static final fun sendSyntaxMessageOrRethrow (Lorg/bukkit/command/CommandSender;Ljava/lang/String;Ljava/lang/Throwable;)V
 }
 
+public final class dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirementsKt {
+	public static final fun withSuspendPlayerRequirement (Ldev/jorel/commandapi/ExecutableCommand;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function3;)V
+	public static synthetic fun withSuspendPlayerRequirement$default (Ldev/jorel/commandapi/ExecutableCommand;Lkotlin/jvm/functions/Function0;ZLkotlin/jvm/functions/Function3;ILjava/lang/Object;)V
+}
+
+public abstract interface class dev/slne/surf/api/paper/command/requirement/SuspendRequirementService {
+	public static final field Companion Ldev/slne/surf/api/paper/command/requirement/SuspendRequirementService$Companion;
+	public abstract fun withSuspendRequirement (Ldev/jorel/commandapi/ExecutableCommand;Lkotlin/jvm/functions/Function0;Lkotlin/jvm/functions/Function3;Z)V
+}
+
+public final class dev/slne/surf/api/paper/command/requirement/SuspendRequirementService$Companion {
+	public final fun getInstance ()Ldev/slne/surf/api/paper/command/requirement/SuspendRequirementService;
+}
+
 public final class dev/slne/surf/api/paper/command/util/AsyncPlayerProfileArgumentUtilsKt {
 	public static final fun awaitAsyncPlayerProfile (Ldev/jorel/commandapi/executors/CommandArguments;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static final fun awaitAsyncPlayerProfileOptional (Ldev/jorel/commandapi/executors/CommandArguments;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
@@ -26,7 +26,7 @@ import org.bukkit.entity.Player
  * execution should also be checked explicitly inside the command executor.
  *
  * @param scope the coroutine scope provider used to refresh the requirement
- * @param allowIfNonPlayer whether non-player command senders should be allowed
+ * @param allowIfNonPlayer whether non-player command senders should bypass this player-only requirement
  * @param requirement the suspendable predicate used to refresh the cached requirement
  * result for a player
  */

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
@@ -9,8 +9,8 @@ import org.bukkit.entity.Player
 
 fun <Impl : ExecutableCommand<Impl, CommandSender>> ExecutableCommand<Impl, CommandSender>.withSuspendPlayerRequirement(
     scope: CoroutineScopeProvider = extractCallingPluginScopeOrThrow(),
-    requirement: suspend CoroutineScope.(Player) -> Boolean,
-    allowIfNonPlayer: Boolean = false
+    allowIfNonPlayer: Boolean = false,
+    requirement: suspend CoroutineScope.(Player) -> Boolean
 ) {
     SuspendRequirementService.instance.apply {
         withSuspendRequirement(scope, requirement, allowIfNonPlayer)

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
@@ -7,6 +7,29 @@ import kotlinx.coroutines.CoroutineScope
 import org.bukkit.command.CommandSender
 import org.bukkit.entity.Player
 
+/**
+ * Adds a suspendable player-only requirement to this command.
+ *
+ * The suspendable [requirement] is refreshed asynchronously when the command tree is sent
+ * to a player. Its result is cached and used by the underlying CommandAPI requirement.
+ *
+ * This means the cached result is still checked when the command is executed, but the
+ * suspendable requirement itself is not refreshed at execution time. The command may
+ * therefore be executed based on the last cached value until the command tree is sent
+ * again and the cache is updated.
+ *
+ * The cached result can be refreshed manually by calling [Player.updateCommands], which
+ * causes the command tree to be resent to the player.
+ *
+ * Because of that, this should mainly be used for command visibility or other visual
+ * command-list behavior. Any condition that must be enforced with up-to-date data during
+ * execution should also be checked explicitly inside the command executor.
+ *
+ * @param scope the coroutine scope provider used to refresh the requirement
+ * @param allowIfNonPlayer whether non-player command senders should be allowed
+ * @param requirement the suspendable predicate used to refresh the cached requirement
+ * result for a player
+ */
 fun <Impl : ExecutableCommand<Impl, CommandSender>> ExecutableCommand<Impl, CommandSender>.withSuspendPlayerRequirement(
     scope: CoroutineScopeProvider = extractCallingPluginScopeOrThrow(),
     allowIfNonPlayer: Boolean = false,

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendCommandRequirements.kt
@@ -1,0 +1,18 @@
+package dev.slne.surf.api.paper.command.requirement
+
+import dev.jorel.commandapi.ExecutableCommand
+import dev.slne.surf.api.paper.command.executors.CoroutineScopeProvider
+import dev.slne.surf.api.paper.command.executors.extractCallingPluginScopeOrThrow
+import kotlinx.coroutines.CoroutineScope
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+fun <Impl : ExecutableCommand<Impl, CommandSender>> ExecutableCommand<Impl, CommandSender>.withSuspendPlayerRequirement(
+    scope: CoroutineScopeProvider = extractCallingPluginScopeOrThrow(),
+    requirement: suspend CoroutineScope.(Player) -> Boolean,
+    allowIfNonPlayer: Boolean = false
+) {
+    SuspendRequirementService.instance.apply {
+        withSuspendRequirement(scope, requirement, allowIfNonPlayer)
+    }
+}

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendRequirementService.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/command/requirement/SuspendRequirementService.kt
@@ -1,0 +1,23 @@
+package dev.slne.surf.api.paper.command.requirement
+
+import dev.jorel.commandapi.ExecutableCommand
+import dev.slne.surf.api.core.util.requiredService
+import dev.slne.surf.api.paper.command.executors.CoroutineScopeProvider
+import dev.slne.surf.api.shared.api.util.InternalSurfApi
+import kotlinx.coroutines.CoroutineScope
+import org.bukkit.command.CommandSender
+import org.bukkit.entity.Player
+
+@InternalSurfApi
+interface SuspendRequirementService {
+
+    fun <Impl : ExecutableCommand<Impl, CommandSender>> ExecutableCommand<Impl, CommandSender>.withSuspendRequirement(
+        scope: CoroutineScopeProvider,
+        requirement: suspend CoroutineScope.(Player) -> Boolean,
+        allowIfNonPlayer: Boolean
+    )
+
+    companion object {
+        val instance = requiredService<SuspendRequirementService>()
+    }
+}


### PR DESCRIPTION
This pull request introduces a new system for suspending and conditionally blocking command packet sending to players, enabling asynchronous or conditional command requirements in the plugin. It adds an infrastructure for "suspendable" command requirements, implements packet blocking for command updates on two Minecraft versions, and provides test commands to demonstrate the new functionality. Additionally, it ensures the new listeners are registered in the plugin lifecycle.

**Core infrastructure for suspendable command requirements:**

* Added `SuspendRequirementServiceImpl` as the implementation for `SuspendRequirementService`, providing coroutine-based, per-player, cacheable command requirements and managing the lifecycle of blocked command packets. It includes an event listener for command updates and connection closures, and registers a version-specific packet blocker listener.
* Introduced `CommandSendPacketBlockerListener` abstract class, which tracks which players should have command packets blocked and exposes a method to remove them from the tracking set.
* Updated `NmsProvider` interface to include a method for creating a `CommandSendPacketBlockerListener` for a set of blocked players.

**Version-specific packet blocker implementations:**

* Implemented `V1_21_11CommandSendPacketBlockerListenerImpl` and `V26_1CommandSendPacketBlockerListenerImpl`, which intercept outgoing command packets and, for blocked players, send a placeholder "commands-are-loading" command tree instead. [[1]](diffhunk://#diff-53881774e9ec4f5358e0c46fd949f8919b2aea94e077ed8161bb4048e1b0063cR1-R55) [[2]](diffhunk://#diff-9fb27539e945f0ad9edca727e7780c65b9f13ddf8314bd6192430206cac14806R1-R56)
* Registered these implementations in their respective `NmsProvider` versions. [[1]](diffhunk://#diff-fe177e1a1fc210d3bf975fd1b3b82967d4c0f149d60499099fa2f13f2c8901a4R94-R97) [[2]](diffhunk://#diff-c1ddd733a1342314c3b642a7ae444a7bda3352d88e369cce9b29f37cd8dc0510R73-R76)

**Integration and registration:**

* Registered the new event and packet listeners in the plugin's listener and packet API loader managers, ensuring proper lifecycle management. [[1]](diffhunk://#diff-901b5262914c01ff6e32ccafd9216db05c67e6dd3446901864b9225205fd0352R21-R22) [[2]](diffhunk://#diff-718d8699cf1dfcc2dc6929194f3457317b3fa8e6211f043f45c31eb9eb19266aR39-R40)

**Testing and demonstration:**

* Added `SuspendRequirementTestCommand` with subcommands to demonstrate and test the suspendable requirement system, including showing/hiding commands and a conditional command that is only available after a delay and if a condition is met.
* Registered the new test command in the test plugin's command list.

**Miscellaneous:**

* Bumped the project version to `3.16.0` in `gradle.properties`.

These changes collectively enable advanced, asynchronous command gating and improve the flexibility of command requirements in the plugin.