### PR TITLE
✨ feat(constraints): add configSizeOrNull function for collection siz…

### DIFF
--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/constraints/CollectionConstraintUtils.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/constraints/CollectionConstraintUtils.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.api.core.config.constraints
+
+import dev.slne.surf.api.core.config.type.StringOrDefault
+
+internal tailrec fun Any?.configSizeOrNull(): Int? = when (this) {
+    null -> null
+    is Collection<*> -> size
+    is Map<*, *> -> size
+    is Array<*> -> size
+    is CharSequence -> length
+    is StringOrDefault -> value?.configSizeOrNull()
+    else -> null
+}


### PR DESCRIPTION
…e retrieval

- implement configSizeOrNull to return size for Collection, Map, Array, CharSequence, and StringOrDefault
- handle null cases gracefully by returning null