### PR TITLE
Add rollLootTable method for loot generation and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.17.2
+version=3.18.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsLootTableBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsLootTableBridgeImpl.kt
@@ -52,4 +52,36 @@ class V1_21_11SurfPaperNmsLootTableBridgeImpl : SurfPaperNmsLootTableBridge {
         return lootTable.getRandomItems(lootParams, nmsEntity.lootTableSeed)
             .mapTo(mutableObjectListOf()) { it.toBukkit() }
     }
+
+    override fun rollLootTable(
+        entity: LivingEntity,
+        damageSource: DamageSource,
+        causedByPlayer: Boolean
+    ): Collection<ItemStack> {
+        val nmsEntity = entity.toNms()
+        val lootTableKey = nmsEntity.lootTable.getOrNull() ?: return emptyObjectList()
+        val lootTable = MinecraftServer.getServer().reloadableRegistries().getLootTable(lootTableKey)
+        val nmsDamageSource = damageSource.toNms()
+
+        val paramBuilder = LootParams.Builder(nmsEntity.level() as ServerLevel)
+            .withParameter(LootContextParams.THIS_ENTITY, nmsEntity)
+            .withParameter(LootContextParams.ORIGIN, nmsEntity.position())
+            .withParameter(LootContextParams.DAMAGE_SOURCE, nmsDamageSource)
+            .withOptionalParameter(LootContextParams.ATTACKING_ENTITY, nmsDamageSource.entity)
+            .withOptionalParameter(
+                LootContextParams.DIRECT_ATTACKING_ENTITY,
+                nmsDamageSource.directEntity
+            )
+
+        val lastHurtByPlayer = nmsEntity.getLastHurtByPlayer()
+        if (causedByPlayer && lastHurtByPlayer != null) {
+            paramBuilder.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, lastHurtByPlayer)
+                .withLuck(lastHurtByPlayer.luck)
+        }
+
+        val lootParams = paramBuilder.create(LootContextParamSets.ENTITY)
+
+        return lootTable.getRandomItems(lootParams, nmsEntity.lootTableSeed)
+            .mapTo(mutableObjectListOf()) { it.toBukkit() }
+    }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsLootTableBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsLootTableBridgeImpl.kt
@@ -53,4 +53,36 @@ class V26_1SurfPaperNmsLootTableBridgeImpl : SurfPaperNmsLootTableBridge {
         return lootTable.getRandomItems(lootParams, nmsEntity.lootTableSeed)
             .mapTo(mutableObjectListOf()) { it.toBukkit() }
     }
+
+    override fun rollLootTable(
+        entity: LivingEntity,
+        damageSource: DamageSource,
+        causedByPlayer: Boolean
+    ): Collection<ItemStack> {
+        val nmsEntity = entity.toNms()
+        val lootTableKey = nmsEntity.lootTable.getOrNull() ?: return emptyObjectList()
+        val lootTable = MinecraftServer.getServer().reloadableRegistries().getLootTable(lootTableKey)
+        val nmsDamageSource = damageSource.toNms()
+
+        val paramBuilder = LootParams.Builder(nmsEntity.level() as ServerLevel)
+            .withParameter(LootContextParams.THIS_ENTITY, nmsEntity)
+            .withParameter(LootContextParams.ORIGIN, nmsEntity.position())
+            .withParameter(LootContextParams.DAMAGE_SOURCE, nmsDamageSource)
+            .withOptionalParameter(LootContextParams.ATTACKING_ENTITY, nmsDamageSource.entity)
+            .withOptionalParameter(
+                LootContextParams.DIRECT_ATTACKING_ENTITY,
+                nmsDamageSource.directEntity
+            )
+
+        val lastHurtByPlayer = nmsEntity.getLastHurtByPlayer()
+        if (causedByPlayer && lastHurtByPlayer != null) {
+            paramBuilder.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, lastHurtByPlayer)
+                .withLuck(lastHurtByPlayer.luck)
+        }
+
+        val lootParams = paramBuilder.create(LootContextParamSets.ENTITY)
+
+        return lootTable.getRandomItems(lootParams, nmsEntity.lootTableSeed)
+            .mapTo(mutableObjectListOf()) { it.toBukkit() }
+    }
 }

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1703,11 +1703,13 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsItemBridge$Co
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge {
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge$Companion;
 	public abstract fun getDifferentLootTable (Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/damage/DamageSource;Lorg/bukkit/entity/EntityType;Z)Ljava/util/Collection;
+	public abstract fun rollLootTable (Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/damage/DamageSource;Z)Ljava/util/Collection;
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge {
 	public fun getDifferentLootTable (Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/damage/DamageSource;Lorg/bukkit/entity/EntityType;Z)Ljava/util/Collection;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge;
+	public fun rollLootTable (Lorg/bukkit/entity/LivingEntity;Lorg/bukkit/damage/DamageSource;Z)Ljava/util/Collection;
 }
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsNbtBridge {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsLootTableBridge.kt
@@ -17,6 +17,12 @@ interface SurfPaperNmsLootTableBridge {
         causedByPlayer: Boolean,
     ): Collection<ItemStack>
 
+    fun rollLootTable(
+        entity: LivingEntity,
+        damageSource: DamageSource,
+        causedByPlayer: Boolean,
+    ): Collection<ItemStack>
+
     companion object : SurfPaperNmsLootTableBridge by bridge {
         val INSTANCE get() = bridge
     }


### PR DESCRIPTION
This pull request introduces a new method for rolling loot tables to the NMS loot table bridge interface and its implementations, and bumps the project version. The main focus is on expanding loot table functionality for both v1_21_11 and v26_1 server versions.

**API Additions:**

* Added a new `rollLootTable` method to the `SurfPaperNmsLootTableBridge` interface, allowing loot tables to be rolled with a given entity, damage source, and player-caused flag. [[1]](diffhunk://#diff-9e52a2d743e79515cad7c29a1836647fb54f2d06a93872061b77b596febab487R20-R25) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1706-R1712)

**Implementation Updates:**

* Implemented the new `rollLootTable` method in both `V1_21_11SurfPaperNmsLootTableBridgeImpl` and `V26_1SurfPaperNmsLootTableBridgeImpl`, providing the logic to roll loot tables using NMS internals for each respective server version. [[1]](diffhunk://#diff-d6b193e06f94cc2ed9142b1dc7f8e25ad85797806069cb4d98ab42c65d2fdcbaR55-R86) [[2]](diffhunk://#diff-b5bd3d41efbd40df8cf85442e42daff52a0dfa5aee38d626b646e6d123a2e166R56-R87)

**Project Versioning:**

* Bumped the project version in `gradle.properties` from `3.17.2` to `3.18.0` to reflect the new API addition.