### PR TITLE
Add isInitialized method to configuration classes and update version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.18.0
+version=3.19.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-core/surf-api-core/api/surf-api-core.api
+++ b/surf-api-core/surf-api-core/api/surf-api-core.api
@@ -150,6 +150,7 @@ public abstract class dev/slne/surf/api/core/config/SpongeConfigClass {
 	public abstract fun getManager ()Ldev/slne/surf/api/core/config/manager/SpongeConfigManager;
 	protected final fun getMigrationBuilder ()Ldev/slne/surf/api/core/config/migration/ConfigMigrationBuilder;
 	public final fun init ()V
+	public abstract fun isInitialized ()Z
 	protected final fun migration (ILdev/slne/surf/api/core/config/migration/ConfigMigration;)V
 	protected final fun migration (ILkotlin/jvm/functions/Function1;)V
 	public final fun reloadFromFile ()Ljava/lang/Object;
@@ -159,12 +160,14 @@ public abstract class dev/slne/surf/api/core/config/SpongeConfigClass {
 
 public abstract class dev/slne/surf/api/core/config/SpongeJsonConfigClass : dev/slne/surf/api/core/config/SpongeConfigClass {
 	public fun <init> (Ljava/lang/Class;Ljava/nio/file/Path;Ljava/lang/String;)V
-	public fun getManager ()Ldev/slne/surf/api/core/config/manager/SpongeConfigManager;
+	public final fun getManager ()Ldev/slne/surf/api/core/config/manager/SpongeConfigManager;
+	public final fun isInitialized ()Z
 }
 
 public abstract class dev/slne/surf/api/core/config/SpongeYmlConfigClass : dev/slne/surf/api/core/config/SpongeConfigClass {
 	public fun <init> (Ljava/lang/Class;Ljava/nio/file/Path;Ljava/lang/String;)V
-	public fun getManager ()Ldev/slne/surf/api/core/config/manager/SpongeConfigManager;
+	public final fun getManager ()Ldev/slne/surf/api/core/config/manager/SpongeConfigManager;
+	public final fun isInitialized ()Z
 }
 
 public abstract interface class dev/slne/surf/api/core/config/SurfConfigApi {

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeConfigClass.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeConfigClass.kt
@@ -79,6 +79,11 @@ sealed class SpongeConfigClass<C>(
     abstract val manager: SpongeConfigManager<C>
 
     /**
+     * Whether the config has been initialized and loaded from disk.
+     */
+    abstract fun isInitialized(): Boolean
+
+    /**
      * Registers a migration for the given target [version].
      *
      * Migrations are applied in version order. For existing configs without a

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeJsonConfigClass.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeJsonConfigClass.kt
@@ -33,18 +33,24 @@ abstract class SpongeJsonConfigClass<C>(
     configClass: Class<C>, configFolder: Path, fileName: String
 ) : SpongeConfigClass<C>(configClass, configFolder, fileName) {
 
-    /**
-     * JSON-backed configuration manager for this config type.
-     *
-     * The manager is created using [SurfConfigApi.createSpongeJsonConfigManager]
-     * with [configClass], [configFolder], [fileName] and [migrationBuilder].
-     */
-    override val manager by lazy {
+    private val managerLazy = lazy {
         surfConfigApi.createSpongeJsonConfigManager(
             configClass,
             configFolder,
             fileName,
             migrationBuilder
         )
+    }
+
+    /**
+     * JSON-backed configuration manager for this config type.
+     *
+     * The manager is created using [SurfConfigApi.createSpongeJsonConfigManager]
+     * with [configClass], [configFolder], [fileName] and [migrationBuilder].
+     */
+    final override val manager by managerLazy
+
+    final override fun isInitialized(): Boolean {
+        return managerLazy.isInitialized()
     }
 }

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeYmlConfigClass.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/config/SpongeYmlConfigClass.kt
@@ -33,18 +33,24 @@ abstract class SpongeYmlConfigClass<C>(
     configClass: Class<C>, configFolder: Path, fileName: String
 ) : SpongeConfigClass<C>(configClass, configFolder, fileName) {
 
-    /**
-     * YAML-backed configuration manager for this config type.
-     *
-     * The manager is created using [SurfConfigApi.createSpongeYmlConfigManager]
-     * with [configClass], [configFolder], [fileName] and [migrationBuilder].
-     */
-    override val manager by lazy {
+    private val managerLazy = lazy {
         surfConfigApi.createSpongeYmlConfigManager(
             configClass,
             configFolder,
             fileName,
             migrationBuilder
         )
+    }
+
+    /**
+     * YAML-backed configuration manager for this config type.
+     *
+     * The manager is created using [SurfConfigApi.createSpongeYmlConfigManager]
+     * with [configClass], [configFolder], [fileName] and [migrationBuilder].
+     */
+    final override val manager by managerLazy
+
+    final override fun isInitialized(): Boolean {
+        return managerLazy.isInitialized()
     }
 }


### PR DESCRIPTION
This pull request introduces an `isInitialized()` method to the configuration class hierarchy, allowing consumers to check if a configuration has been loaded from disk. It also refactors the initialization logic for configuration managers to improve encapsulation and consistency. The project version is incremented as part of this release.

### Config system improvements

* Added the abstract method `isInitialized()` to `SpongeConfigClass`, enabling all config types to report their initialization state. [[1]](diffhunk://#diff-70c55400e6f9dce0119d2241288e1fc724b755d447c48cca2d53c0813bc64651R153) [[2]](diffhunk://#diff-606a9a3f428e5d858d8491ee72ef60a1d056323c2291454d0025d5067a2096b8R81-R85)
* Implemented `isInitialized()` in both `SpongeJsonConfigClass` and `SpongeYmlConfigClass` by exposing the state of their respective lazy manager initializations. [[1]](diffhunk://#diff-70c55400e6f9dce0119d2241288e1fc724b755d447c48cca2d53c0813bc64651L162-R170) [[2]](diffhunk://#diff-c5276a34b93da974b13cad7ce5c329f550f884662046ec2b586902db7f8ad1a5L36-R55) [[3]](diffhunk://#diff-147cb6b6adc8d703a1fb6fe6165c88d24efb8e6773ac93a4796abcb5ed8853b8L36-R55)
* Refactored the manager initialization in `SpongeJsonConfigClass` and `SpongeYmlConfigClass` to use a private `managerLazy` property, improving encapsulation and allowing access to the initialization state. [[1]](diffhunk://#diff-c5276a34b93da974b13cad7ce5c329f550f884662046ec2b586902db7f8ad1a5L36-R55) [[2]](diffhunk://#diff-147cb6b6adc8d703a1fb6fe6165c88d24efb8e6773ac93a4796abcb5ed8853b8L36-R55)

### Versioning

* Bumped the project version to `3.19.0` in `gradle.properties` to reflect these API and implementation changes.