### PR TITLE
Bump version to 3.20.0 and refactor binary tag handling

### DIFF
--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -71,7 +71,9 @@ tasks {
         duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
         val relocationPrefix: String by project
-        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt")
+        relocate("net.kyori.adventure.nbt", "$relocationPrefix.kyori.nbt") {
+            exclude("net.kyori.adventure.nbt.api.**")
+        }
         relocate("org.spongepowered.configurate", "$relocationPrefix.configurate")
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.19.0
+version=3.20.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-core/surf-api-core/api/surf-api-core.api
+++ b/surf-api-core/surf-api-core/api/surf-api-core.api
@@ -8902,6 +8902,9 @@ public final class dev/slne/surf/api/core/nbt/InternalNbtBridge$Companion : dev/
 }
 
 public final class dev/slne/surf/api/core/nbt/Nbt_extensionKt {
+	public static final fun asTagHolder (Lnet/kyori/adventure/nbt/BinaryTag;)Lnet/kyori/adventure/nbt/api/BinaryTagHolder;
+	public static final fun decodeCompoundTag (Lnet/kyori/adventure/nbt/api/BinaryTagHolder;)Lnet/kyori/adventure/nbt/CompoundBinaryTag;
+	public static final fun decodeTag (Lnet/kyori/adventure/nbt/api/BinaryTagHolder;)Lnet/kyori/adventure/nbt/BinaryTag;
 	public static final fun isCollectionTag (Lnet/kyori/adventure/nbt/BinaryTag;)Z
 	public static final fun tagIterator (Lnet/kyori/adventure/nbt/ByteArrayBinaryTag;)Ljava/util/Iterator;
 	public static final fun tagIterator (Lnet/kyori/adventure/nbt/IntArrayBinaryTag;)Ljava/util/Iterator;

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/nbt/nbt-extension.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/nbt/nbt-extension.kt
@@ -1,9 +1,42 @@
 package dev.slne.surf.api.core.nbt
 
 import net.kyori.adventure.nbt.*
+import net.kyori.adventure.nbt.api.BinaryTagHolder
+import net.kyori.adventure.util.Codec
+import java.io.IOException
 import java.util.*
 import java.util.stream.Stream
 import java.util.stream.StreamSupport
+
+private val binaryTagHolderCodec = object : Codec<BinaryTag, String, IOException, IOException> {
+    private val tagStringIO = TagStringIO.builder()
+        .acceptLegacy(false)
+        .build()
+
+    override fun decode(encoded: String): BinaryTag {
+        return tagStringIO.asTag(encoded)
+    }
+
+    override fun encode(decoded: BinaryTag): String {
+        return tagStringIO.asString(decoded)
+    }
+}
+
+fun BinaryTag.asTagHolder(): BinaryTagHolder {
+    return BinaryTagHolder.encode(this, binaryTagHolderCodec)
+}
+
+fun BinaryTagHolder.decodeTag(): BinaryTag {
+    return get(binaryTagHolderCodec)
+}
+
+fun BinaryTagHolder.decodeCompoundTag(): CompoundBinaryTag {
+    val decoded = get(binaryTagHolderCodec)
+    if (decoded !is CompoundBinaryTag) {
+        error("Expected a CompoundBinaryTag, but got ${decoded::class.simpleName}")
+    }
+    return decoded
+}
 
 fun BinaryTag.isCollectionTag() =
     this is ListBinaryTag || this is ByteArrayBinaryTag || this is LongArrayBinaryTag || this is IntArrayBinaryTag

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 group = groupId
 version = buildString {
-    append("2.0.7")
+    append("2.0.8")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
@@ -35,7 +35,7 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
         "com.google.devtools.ksp"
     )
 
-    private val relocations = mutableMapOf<String, String>()
+    private val relocations = mutableListOf<Relocation>()
     private val dependencyDependentRelocations = mutableMapOf<String, MutableMap<String, String>>()
 
     init {
@@ -70,7 +70,15 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
     }
 
     protected infix fun String.relocatesTo(to: String) {
-        relocations[this] = to
+        relocations += Relocation(this, to)
+    }
+
+    protected fun relocatePackage(
+        from: String,
+        to: String,
+        excludes: List<String> = emptyList(),
+    ) {
+        relocations += Relocation(from, to, excludes)
     }
 
     fun addRelocationsForDependency(
@@ -116,8 +124,13 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
 
     private fun Project.configure() {
         tasks.withType<ShadowJar> {
-            relocations.forEach { (from, to) ->
-                relocate(from, "${Constants.RELOCATION_PREFIX}.$to")
+            relocations.forEach { relocation ->
+                relocate(
+                    relocation.from,
+                    "${Constants.RELOCATION_PREFIX}.${relocation.to}"
+                ) {
+                    relocation.excludes.forEach { exclude(it) }
+                }
             }
         }
 
@@ -285,4 +298,10 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
 
     protected open fun Project.afterEvaluated0(extension: E) {
     }
+
+    private data class Relocation(
+        val from: String,
+        val to: String,
+        val excludes: List<String> = emptyList(),
+    )
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/core/CoreSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/core/CoreSurfPlugin.kt
@@ -10,7 +10,11 @@ internal abstract class AbstractCoreSurfPlugin<E : CoreSurfExtension>(
     init {
         "com.mojang.serialization" relocatesTo "mojang.serialization"
         "com.mojang.datafixers" relocatesTo "mojang.datafixers"
-        "net.kyori.adventure.nbt" relocatesTo "kyori.nbt"
+        relocatePackage(
+            from = "net.kyori.adventure.nbt",
+            to = "kyori.nbt",
+            excludes = listOf("net.kyori.adventure.nbt.api.**")
+        )
     }
 
     final override fun Project.afterEvaluated0(extension: E) {


### PR DESCRIPTION
This pull request introduces several improvements and new features related to NBT (Named Binary Tag) handling and Gradle relocation logic, along with some version bumps. The main highlights are the addition of utility functions for encoding/decoding NBT tags, enhanced relocation logic that supports package exclusions, and corresponding configuration updates.

**NBT Utilities:**

* Added utility functions in `nbt-extension.kt` for encoding a `BinaryTag` as a `BinaryTagHolder` and decoding a `BinaryTagHolder` back to a `BinaryTag` or specifically a `CompoundBinaryTag`. This provides a type-safe and convenient way to serialize and deserialize NBT data. [[1]](diffhunk://#diff-6aff5cc16c0a4525285f66bdb59a02794e495eadf52bd17ed4a4f26867aa652fR4-R40) [[2]](diffhunk://#diff-70c55400e6f9dce0119d2241288e1fc724b755d447c48cca2d53c0813bc64651R8905-R8907)

**Relocation Logic Enhancements:**

* Refactored relocation logic in `CommonSurfPlugin` to support specifying exclusions when relocating packages, by introducing a `Relocation` data class and updating related methods and usages. [[1]](diffhunk://#diff-12d25a396937371c76bad332dba36c1ca64852339ba7289cfe43693a150c6020L38-R38) [[2]](diffhunk://#diff-12d25a396937371c76bad332dba36c1ca64852339ba7289cfe43693a150c6020L73-R81) [[3]](diffhunk://#diff-12d25a396937371c76bad332dba36c1ca64852339ba7289cfe43693a150c6020L119-R133) [[4]](diffhunk://#diff-12d25a396937371c76bad332dba36c1ca64852339ba7289cfe43693a150c6020R301-R306)
* Updated the core plugin to use the new `relocatePackage` method for `net.kyori.adventure.nbt`, excluding the `net.kyori.adventure.nbt.api.**` package from relocation.
* Modified the Gradle shadow JAR relocation in `core-convention.gradle.kts` to exclude `net.kyori.adventure.nbt.api.**` from relocation, preventing conflicts or issues with API classes.

**Version Bumps:**

* Bumped `surf-api-core` version to `3.20.0` and `surf-api-gradle-plugin` version to `2.0.8` to reflect the new features and changes. [[1]](diffhunk://#diff-3d103fc7c312a3e136f88e81cef592424b8af2464c468116545c4d22d6edcf19L10-R10) [[2]](diffhunk://#diff-2e36ad9dcce88f8b5727df509328b34dae36f5121e3c833790b233c87a79c54eL23-R23)