### PR TITLE
Add chat data classes and improve session handling methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.21.0
+version=3.22.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.PlayerInventoryEdit
 import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
+import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatSessionSnapshot
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import dev.slne.surf.api.paper.nms.common.dummy.DummyEntityEquipment
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toNms
@@ -62,6 +63,17 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             key = profilePublicKey.key(),
             keySignature = profilePublicKey.keySignature()
         )
+    }
+
+    override fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot? {
+        TODO("Not yet implemented")
+    }
+
+    override fun applyChatSessionSnapshot(
+        player: Player,
+        snapshot: PlayerChatSessionSnapshot
+    ) {
+        TODO("Not yet implemented")
     }
 
     @Suppress("USELESS_ELVIS")

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -66,14 +66,18 @@ class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     override fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot? {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException("1.21.11")
     }
 
     override fun applyChatSessionSnapshot(
         player: Player,
         snapshot: PlayerChatSessionSnapshot
     ) {
-        TODO("Not yet implemented")
+        throw UnsupportedOperationException("1.21.11")
+    }
+
+    override fun <T> withMessageSignatureCacheLock(player: Player, block: () -> T): T? {
+        throw UnsupportedOperationException("1.21.11")
     }
 
     @Suppress("USELESS_ELVIS")

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -69,6 +69,13 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     @Suppress("USELESS_ELVIS")
+    override fun <T> withMessageSignatureCacheLock(player: Player, block: () -> T): T? {
+        val connection = player.toNms().connection ?: return null
+        val cache = V26_1NmsReflections.getMessageSignatureCache(connection)
+        return synchronized(cache) { block() }
+    }
+
+    @Suppress("USELESS_ELVIS")
     override fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot? {
         val nmsPlayer = player.toNms()
         val connection = nmsPlayer.connection ?: return null

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -25,6 +25,7 @@ import net.minecraft.nbt.CompoundTag
 import net.minecraft.nbt.NbtIo
 import net.minecraft.network.chat.*
 import net.minecraft.network.protocol.game.ClientboundPlayerChatPacket
+import net.minecraft.network.protocol.game.ClientboundPlayerInfoUpdatePacket
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.players.NameAndId
 import net.minecraft.util.ProblemReporter
@@ -68,6 +69,189 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
     }
 
     @Suppress("USELESS_ELVIS")
+    override fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot? {
+        val nmsPlayer = player.toNms()
+        val connection = nmsPlayer.connection ?: return null
+
+        val lastSeenMessages = V26_1NmsReflections.getLastSeenMessages(connection)
+        val messageSignatureCache = V26_1NmsReflections.getMessageSignatureCache(connection)
+
+        return synchronized(lastSeenMessages) {
+            synchronized(messageSignatureCache) {
+                val nextChatIndex = V26_1NmsReflections.getNextChatIndex(connection)
+                val chatSession = V26_1NmsReflections.getRemoteChatSession(connection) ?: return null
+
+                val lastSeenMessagesMirror = LastSeenMessagesValidatorMirror(
+                    lastSeenCount = V26_1NmsReflections.getLastSeenCountFromMessageValidator(lastSeenMessages),
+                    trackedMessages = V26_1NmsReflections.getTrackedMessagesFromMessageValidator(lastSeenMessages)
+                        .map { entry ->
+                            entry?.let {
+                                LastSeenMessagesValidatorMirror.LastSeenTrackedEntry(
+                                    it.signature().bytes(),
+                                    it.pending()
+                                )
+                            }
+                        },
+                    lastPendingMessage = V26_1NmsReflections.getLastPendingMessageFromMessageValidator(lastSeenMessages)
+                        ?.bytes()
+                )
+
+                val messageSignatureCacheEntries =
+                    V26_1NmsReflections.getEntriesFromMessageSignatureCache(messageSignatureCache)
+                val messageSignatureCacheMirror = Array(messageSignatureCacheEntries.size) { i ->
+                    messageSignatureCacheEntries[i]?.bytes()
+                }
+
+                val chatSessionData = chatSession.asData()
+                val chatSessionMirror = RemoteChatSessionData(
+                    chatSessionData.sessionId,
+                    chatSessionData.profilePublicKey.expiresAt,
+                    chatSessionData.profilePublicKey.key,
+                    chatSessionData.profilePublicKey.keySignature
+                )
+
+                val messageDecoder = V26_1NmsReflections.getSignedMessageDecoder(connection)
+                val signedMessageChain = messageDecoder.signedMessageChain()
+
+                val chatChainMirror = IncomingChatChainMirror(
+                    nextLinkIndex = V26_1NmsReflections.getNextLinkFromSignedMessageChain(signedMessageChain)?.index,
+                    lastTimeStamp = V26_1NmsReflections.getLastTimeStampFromSignedMessageChain(signedMessageChain)
+                )
+
+                PlayerChatSessionSnapshot(
+                    nextChatIndex = nextChatIndex,
+                    chatSession = chatSessionMirror,
+                    lastSeenMessages = lastSeenMessagesMirror,
+                    messageSignatureCache = messageSignatureCacheMirror,
+                    incomingChatChain = chatChainMirror
+                )
+            }
+        }
+    }
+
+    @Suppress("USELESS_ELVIS")
+    override fun applyChatSessionSnapshot(player: Player, snapshot: PlayerChatSessionSnapshot) {
+        val nmsPlayer = player.toNms()
+        val connection = nmsPlayer.connection ?: return
+        val chatSessionMirror = snapshot.chatSession ?: return
+
+        val profileKeySignatureValidator = MinecraftServer.getServer().services().profileKeySignatureValidator()
+        if (profileKeySignatureValidator == null) {
+            CHAT_LOGGER.warn(
+                "Ignoring chat session from {} due to missing Services public key",
+                nmsPlayer.gameProfile.name
+            )
+            return
+        }
+
+        val newChatSession = RemoteChatSession.Data(
+            chatSessionMirror.sessionId,
+            ProfilePublicKey.Data(
+                chatSessionMirror.expiresAt,
+                chatSessionMirror.key,
+                chatSessionMirror.keySignature
+            )
+        )
+
+        val chatSession = newChatSession.validate(nmsPlayer.gameProfile, profileKeySignatureValidator)
+
+        val lastSeenMessages = V26_1NmsReflections.getLastSeenMessages(connection)
+        val messageSignatureCache = V26_1NmsReflections.getMessageSignatureCache(connection)
+
+        synchronized(lastSeenMessages) {
+            synchronized(messageSignatureCache) {
+                V26_1NmsReflections.setNextChatIndex(connection, snapshot.nextChatIndex)
+
+                val lastSeenCount = V26_1NmsReflections.getLastSeenCountFromMessageValidator(lastSeenMessages)
+                val trackedMessages = V26_1NmsReflections.getTrackedMessagesFromMessageValidator(lastSeenMessages)
+
+                val lastSeenMessagesMirror = snapshot.lastSeenMessages
+                val lastSeenCountMirror = lastSeenMessagesMirror.lastSeenCount
+                val trackedMessagesMirror = lastSeenMessagesMirror.trackedMessages
+                val lastPendingMessageMirror = lastSeenMessagesMirror.lastPendingMessage
+
+                if (lastSeenCount != lastSeenCountMirror) {
+                    CHAT_LOGGER.warn(
+                        "Chat session from {} has lastSeenCount mismatch: expected={}, actual={}",
+                        nmsPlayer.gameProfile.name, lastSeenCountMirror, lastSeenCount
+                    )
+                }
+
+                trackedMessages.clear()
+                for (entry in trackedMessagesMirror) {
+                    if (entry == null) {
+                        trackedMessages.add(null)
+                    } else {
+                        trackedMessages.add(
+                            LastSeenTrackedEntry(MessageSignature(entry.signature), entry.pending)
+                        )
+                    }
+                }
+
+                val lastPendingMessage = lastPendingMessageMirror?.let { MessageSignature(it) }
+                V26_1NmsReflections.setLastPendingMessageFromMessageValidator(lastSeenMessages, lastPendingMessage)
+
+                val messageSignatureCacheEntries =
+                    V26_1NmsReflections.getEntriesFromMessageSignatureCache(messageSignatureCache)
+                val messageSignatureCacheMirror = snapshot.messageSignatureCache
+
+                if (messageSignatureCacheEntries.size != messageSignatureCacheMirror.size) {
+                    CHAT_LOGGER.warn(
+                        "Chat session from {} has messageSignatureCache size mismatch: expected={}, actual={}",
+                        nmsPlayer.gameProfile.name, messageSignatureCacheMirror.size, messageSignatureCacheEntries.size
+                    )
+                }
+
+                for (i in messageSignatureCacheEntries.indices) {
+                    messageSignatureCacheEntries[i] =
+                        if (i >= messageSignatureCacheMirror.size) null
+                        else messageSignatureCacheMirror[i]?.let { MessageSignature(it) }
+                }
+            }
+        }
+
+        V26_1NmsReflections.setRemoteChatSession(connection, chatSession)
+        V26_1NmsReflections.setHasLoggedExpiry(connection, false)
+
+        val messageChain = SignedMessageChain(nmsPlayer.uuid, chatSession.sessionId)
+        V26_1NmsReflections.setLastTimeStampFromSignedMessageChain(
+            messageChain,
+            snapshot.incomingChatChain.lastTimeStamp
+        )
+        V26_1NmsReflections.setNextLinkFromSignedMessageChain(
+            messageChain,
+            snapshot.incomingChatChain.nextLinkIndex?.let { index ->
+                SignedMessageLink(index, nmsPlayer.uuid, chatSession.sessionId)
+            }
+        )
+
+        val signedMessageDecoder = messageChain.decoder(chatSession.profilePublicKey)
+        V26_1NmsReflections.setSignedMessageDecoder(connection, signedMessageDecoder)
+
+        val chatChain = V26_1NmsReflections.getChatMessageChain(connection)
+        chatChain.append {
+            nmsPlayer.setChatSession(chatSession)
+            MinecraftServer.getServer().playerList.broadcastAll(
+                ClientboundPlayerInfoUpdatePacket(
+                    EnumSet.of(ClientboundPlayerInfoUpdatePacket.Action.INITIALIZE_CHAT),
+                    listOf(nmsPlayer)
+                ),
+                nmsPlayer
+            )
+        }
+    }
+
+    private fun SignedMessageChain.Decoder.signedMessageChain(): SignedMessageChain {
+        try {
+            val field = javaClass.getDeclaredField("this$0")
+            field.trySetAccessible()
+            return field.get(this) as SignedMessageChain
+        } catch (e: Throwable) {
+            throw RuntimeException("Failed to access signedMessageChain from decoder $this", e)
+        }
+    }
+
+    @Suppress("USELESS_ELVIS")
     override fun resetPlayerChatState(player: Player, chatSession: RemoteChatSessionData) {
         val nmsPlayer = player.toNms()
         val connection = nmsPlayer.connection ?: return
@@ -92,7 +276,7 @@ class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
             signatureValidator
         )
 
-        V26_1NmsReflections.resetPlayerChatState(connection, newChatSession,)
+        V26_1NmsReflections.resetPlayerChatState(connection, newChatSession)
     }
 
     override fun runOnChatMessageChain(player: Player, scope: CoroutineScope, block: suspend () -> Unit) {

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/reflection/V26_1NmsReflections.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/reflection/V26_1NmsReflections.kt
@@ -5,6 +5,7 @@ import com.google.gson.JsonElement
 import dev.slne.surf.api.shared.api.reflection.*
 import io.netty.channel.ChannelFuture
 import io.papermc.paper.adventure.ChatProcessor
+import it.unimi.dsi.fastutil.objects.ObjectList
 import net.minecraft.network.chat.*
 import net.minecraft.network.syncher.EntityDataAccessor
 import net.minecraft.resources.ResourceKey
@@ -14,6 +15,7 @@ import net.minecraft.stats.ServerStatsCounter
 import net.minecraft.util.FutureChain
 import net.minecraft.world.entity.Entity
 import java.lang.invoke.VarHandle
+import java.time.Instant
 import java.util.*
 
 @Suppress("ClassName")
@@ -29,11 +31,35 @@ interface V26_1NmsReflections {
     @ConstantIntArgument(1)
     fun getAndIncreaseNextChatIndex(instance: ServerGamePacketListenerImpl): Int
 
+    @ReflectedField("nextChatIndex")
+    fun getNextChatIndex(instance: ServerGamePacketListenerImpl): Int
+
+    @ReflectedField("nextChatIndex", access = ReflectedFieldAccess.SET)
+    fun setNextChatIndex(instance: ServerGamePacketListenerImpl, index: Int)
+
     @ReflectedField("messageSignatureCache")
     fun getMessageSignatureCache(instance: ServerGamePacketListenerImpl): MessageSignatureCache
 
+    @ReflectedMethod("push")
+    fun pushMessageSignatureCache(instance: MessageSignatureCache, deque: ArrayDeque<MessageSignature>)
+
     @ReflectedField(name = "lastSeenMessages")
     fun getLastSeenMessages(instance: ServerGamePacketListenerImpl): LastSeenMessagesValidator
+
+    @ReflectedField("lastSeenCount")
+    fun getLastSeenCountFromMessageValidator(validator: LastSeenMessagesValidator): Int
+
+    @ReflectedField("trackedMessages")
+    fun getTrackedMessagesFromMessageValidator(validator: LastSeenMessagesValidator): ObjectList<LastSeenTrackedEntry?>
+
+    @ReflectedField("lastPendingMessage")
+    fun getLastPendingMessageFromMessageValidator(validator: LastSeenMessagesValidator): MessageSignature?
+
+    @ReflectedField("lastPendingMessage", access = ReflectedFieldAccess.SET)
+    fun setLastPendingMessageFromMessageValidator(validator: LastSeenMessagesValidator, message: MessageSignature?)
+
+    @ReflectedField("entries")
+    fun getEntriesFromMessageSignatureCache(cache: MessageSignatureCache): Array<MessageSignature?>
 
     @ReflectedConstructor
     fun createFilterMask(bitSet: BitSet): FilterMask
@@ -82,6 +108,33 @@ interface V26_1NmsReflections {
     )
     fun getServerStatsCounterGson(): Gson
 
+    @ReflectedField("signedMessageDecoder")
+    fun getSignedMessageDecoder(instance: ServerGamePacketListenerImpl): SignedMessageChain.Decoder
+
+    @ReflectedField("signedMessageDecoder", access = ReflectedFieldAccess.SET)
+    fun setSignedMessageDecoder(
+        instance: ServerGamePacketListenerImpl,
+        decoder: SignedMessageChain.Decoder
+    )
+
+    @ReflectedField("nextLink")
+    fun getNextLinkFromSignedMessageChain(chain: SignedMessageChain): SignedMessageLink?
+
+    @ReflectedField("nextLink", access = ReflectedFieldAccess.SET)
+    fun setNextLinkFromSignedMessageChain(
+        chain: SignedMessageChain,
+        nextLink: SignedMessageLink?
+    )
+
+    @ReflectedField("lastTimeStamp")
+    fun getLastTimeStampFromSignedMessageChain(chain: SignedMessageChain): Instant
+
+    @ReflectedField("lastTimeStamp", access = ReflectedFieldAccess.SET)
+    fun setLastTimeStampFromSignedMessageChain(
+        chain: SignedMessageChain,
+        lastTimeStamp: Instant
+    )
+
     @ReflectedMethod("resetPlayerChatState")
     fun resetPlayerChatState(
         instance: ServerGamePacketListenerImpl,
@@ -90,6 +143,18 @@ interface V26_1NmsReflections {
 
     @ReflectedField("chatSession")
     fun getRemoteChatSession(instance: ServerGamePacketListenerImpl): RemoteChatSession?
+
+    @ReflectedField("chatSession", access = ReflectedFieldAccess.SET)
+    fun setRemoteChatSession(
+        instance: ServerGamePacketListenerImpl,
+        chatSession: RemoteChatSession?
+    )
+
+    @ReflectedField("hasLoggedExpiry", access = ReflectedFieldAccess.SET)
+    fun setHasLoggedExpiry(
+        instance: ServerGamePacketListenerImpl,
+        value: Boolean
+    )
 
     companion object : V26_1NmsReflections by generatedReflectionAccessor()
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/reflection/V26_1NmsReflections.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/reflection/V26_1NmsReflections.kt
@@ -9,11 +9,13 @@ import it.unimi.dsi.fastutil.objects.ObjectList
 import net.minecraft.network.chat.*
 import net.minecraft.network.syncher.EntityDataAccessor
 import net.minecraft.resources.ResourceKey
+import net.minecraft.server.level.ServerPlayer
 import net.minecraft.server.network.ServerConnectionListener
 import net.minecraft.server.network.ServerGamePacketListenerImpl
 import net.minecraft.stats.ServerStatsCounter
 import net.minecraft.util.FutureChain
 import net.minecraft.world.entity.Entity
+import net.minecraft.world.entity.player.ChatVisiblity
 import java.lang.invoke.VarHandle
 import java.time.Instant
 import java.util.*
@@ -155,6 +157,12 @@ interface V26_1NmsReflections {
         instance: ServerGamePacketListenerImpl,
         value: Boolean
     )
+
+    @ReflectedVarHandle(
+        name = "chatVisibility",
+        mode = VarHandle.AccessMode.GET_AND_SET
+    )
+    fun getAndSetChatVisibility(player: ServerPlayer, visibility: ChatVisiblity): ChatVisiblity
 
     companion object : V26_1NmsReflections by generatedReflectionAccessor()
 }

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1726,7 +1726,9 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsNbtBridge$Com
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion;
+	public abstract fun applyChatSessionSnapshot (Lorg/bukkit/entity/Player;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;)V
 	public abstract fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
+	public abstract fun createChatSessionSnapshot (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;
 	public abstract fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public abstract fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
@@ -1739,10 +1741,13 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
 	public abstract fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
+	public abstract fun withMessageSignatureCacheLock (Lorg/bukkit/entity/Player;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge {
+	public fun applyChatSessionSnapshot (Lorg/bukkit/entity/Player;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;)V
 	public fun createAdventureChatMessageFromMirror (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;)Lnet/kyori/adventure/chat/SignedMessage;
+	public fun createChatSessionSnapshot (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;
 	public fun createPlayerChatMessageMirrorFromAdventure (Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
 	public fun editOfflineInventory (Lcom/destroystokyo/paper/profile/PlayerProfile;Lkotlin/jvm/functions/Function1;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;
@@ -1755,6 +1760,7 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
 	public fun sendSignedMessageWithChangedContent (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;Lnet/kyori/adventure/text/Component;)V
+	public fun withMessageSignatureCacheLock (Lorg/bukkit/entity/Player;Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$DefaultImpls {
@@ -1784,6 +1790,96 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge$C
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsStatsBridge;
 	public fun getPlayerStatsAsJson (Lorg/bukkit/entity/Player;)Ljava/lang/String;
 	public fun savePlayerStatsToFile (Lorg/bukkit/entity/Player;)V
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror$Companion;
+	public fun <init> (Ljava/lang/Integer;Ljava/time/Instant;)V
+	public final fun component1 ()Ljava/lang/Integer;
+	public final fun component2 ()Ljava/time/Instant;
+	public final fun copy (Ljava/lang/Integer;Ljava/time/Instant;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;Ljava/lang/Integer;Ljava/time/Instant;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastTimeStamp ()Ljava/time/Instant;
+	public final fun getNextLinkIndex ()Ljava/lang/Integer;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$Companion;
+	public fun <init> (ILjava/util/List;[B)V
+	public synthetic fun <init> (ILjava/util/List;[BILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ljava/util/List;
+	public final fun component3 ()[B
+	public final fun copy (ILjava/util/List;[B)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;ILjava/util/List;[BILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getLastPendingMessage ()[B
+	public final fun getLastSeenCount ()I
+	public final fun getTrackedMessages ()Ljava/util/List;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry$Companion;
+	public fun <init> ([BZ)V
+	public final fun component1 ()[B
+	public final fun component2 ()Z
+	public final fun copy ([BZ)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry;[BZILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getPending ()Z
+	public final fun getSignature ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror$LastSeenTrackedEntry$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror {
@@ -1950,6 +2046,41 @@ public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/Playe
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror$SignedMessageLink$Companion {
+	public final fun serializer ()Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot {
+	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot$Companion;
+	public fun <init> (ILdev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;[[BLdev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;)V
+	public final fun component1 ()I
+	public final fun component2 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public final fun component3 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;
+	public final fun component4 ()[[B
+	public final fun component5 ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;
+	public final fun copy (ILdev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;[[BLdev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;
+	public static synthetic fun copy$default (Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;ILdev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;[[BLdev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getChatSession ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
+	public final fun getIncomingChatChain ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror;
+	public final fun getLastSeenMessages ()Ldev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror;
+	public final fun getMessageSignatureCache ()[[B
+	public final fun getNextChatIndex ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final synthetic class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot$$serializer : kotlinx/serialization/internal/GeneratedSerializer {
+	public static final field INSTANCE Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot$$serializer;
+	public final fun childSerializers ()[Lkotlinx/serialization/KSerializer;
+	public final fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;
+	public synthetic fun deserialize (Lkotlinx/serialization/encoding/Decoder;)Ljava/lang/Object;
+	public final fun getDescriptor ()Lkotlinx/serialization/descriptors/SerialDescriptor;
+	public final fun serialize (Lkotlinx/serialization/encoding/Encoder;Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot;)V
+	public synthetic fun serialize (Lkotlinx/serialization/encoding/Encoder;Ljava/lang/Object;)V
+	public fun typeParametersSerializers ()[Lkotlinx/serialization/KSerializer;
+}
+
+public final class dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot$Companion {
 	public final fun serializer ()Lkotlinx/serialization/KSerializer;
 }
 

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -5,6 +5,7 @@ import dev.slne.surf.api.core.util.requiredService
 import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import dev.slne.surf.api.paper.nms.bridges.SurfPaperNmsPlayerBridge.Companion.editOfflineInventory
 import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatMessageMirror
+import dev.slne.surf.api.paper.nms.bridges.data.chat.PlayerChatSessionSnapshot
 import dev.slne.surf.api.paper.nms.bridges.data.chat.RemoteChatSessionData
 import kotlinx.coroutines.CoroutineScope
 import net.kyori.adventure.chat.ChatType
@@ -22,6 +23,9 @@ import java.nio.file.Path
 interface SurfPaperNmsPlayerBridge {
 
     fun getRemoteChatSessionData(player: Player): RemoteChatSessionData?
+
+    fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot?
+    fun applyChatSessionSnapshot(player: Player, snapshot: PlayerChatSessionSnapshot)
 
     fun resetPlayerChatState(player: Player, chatSession: RemoteChatSessionData)
 

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -27,6 +27,8 @@ interface SurfPaperNmsPlayerBridge {
     fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot?
     fun applyChatSessionSnapshot(player: Player, snapshot: PlayerChatSessionSnapshot)
 
+    fun <T> withMessageSignatureCacheLock(player: Player, block: () -> T): T?
+
     fun resetPlayerChatState(player: Player, chatSession: RemoteChatSessionData)
 
     fun runOnChatMessageChain(player: Player, scope: CoroutineScope, block: suspend () -> Unit)

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/IncomingChatChainMirror.kt
@@ -1,0 +1,13 @@
+package dev.slne.surf.api.paper.nms.bridges.data.chat
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import kotlinx.serialization.Contextual
+import kotlinx.serialization.Serializable
+import java.time.Instant
+
+@NmsUseWithCaution
+@Serializable
+data class IncomingChatChainMirror(
+    val nextLinkIndex: Int?,
+    val lastTimeStamp: @Contextual Instant,
+)

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/LastSeenMessagesValidatorMirror.kt
@@ -1,0 +1,54 @@
+package dev.slne.surf.api.paper.nms.bridges.data.chat
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import kotlinx.serialization.Serializable
+
+@Serializable
+@NmsUseWithCaution
+data class LastSeenMessagesValidatorMirror(
+    val lastSeenCount: Int,
+    val trackedMessages: List<LastSeenTrackedEntry?>,
+    val lastPendingMessage: ByteArray? = null,
+) {
+
+    @Serializable
+    @NmsUseWithCaution
+    data class LastSeenTrackedEntry(
+        val signature: ByteArray,
+        val pending: Boolean
+    ) {
+        override fun equals(other: Any?): Boolean {
+            if (this === other) return true
+            if (other !is LastSeenTrackedEntry) return false
+
+            if (pending != other.pending) return false
+            if (!signature.contentEquals(other.signature)) return false
+
+            return true
+        }
+
+        override fun hashCode(): Int {
+            var result = pending.hashCode()
+            result = 31 * result + signature.contentHashCode()
+            return result
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is LastSeenMessagesValidatorMirror) return false
+
+        if (lastSeenCount != other.lastSeenCount) return false
+        if (trackedMessages != other.trackedMessages) return false
+        if (!lastPendingMessage.contentEquals(other.lastPendingMessage)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = lastSeenCount
+        result = 31 * result + trackedMessages.hashCode()
+        result = 31 * result + (lastPendingMessage?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatSessionSnapshot.kt
@@ -1,0 +1,34 @@
+package dev.slne.surf.api.paper.nms.bridges.data.chat
+
+import dev.slne.surf.api.paper.nms.NmsUseWithCaution
+import kotlinx.serialization.Serializable
+
+@NmsUseWithCaution
+@Serializable
+data class PlayerChatSessionSnapshot(
+    val nextChatIndex: Int,
+    val chatSession: RemoteChatSessionData?,
+    val lastSeenMessages: LastSeenMessagesValidatorMirror,
+    val messageSignatureCache: Array<ByteArray?>,
+    val incomingChatChain: IncomingChatChainMirror
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PlayerChatSessionSnapshot) return false
+
+        if (nextChatIndex != other.nextChatIndex) return false
+        if (chatSession != other.chatSession) return false
+        if (lastSeenMessages != other.lastSeenMessages) return false
+        if (!messageSignatureCache.contentDeepEquals(other.messageSignatureCache)) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = nextChatIndex
+        result = 31 * result + chatSession.hashCode()
+        result = 31 * result + lastSeenMessages.hashCode()
+        result = 31 * result + messageSignatureCache.contentDeepHashCode()
+        return result
+    }
+}


### PR DESCRIPTION
This pull request introduces a new system for capturing and restoring a player's chat session state, primarily targeting Minecraft 1.21.11 and 1.26.1 server versions. It adds data mirror classes, interface methods, and reflection helpers to snapshot and restore chat session internals, including message signature caches and chat chains. The implementation is complete for 1.26.1, while 1.21.11 stubs out the new functionality with exceptions.

**Chat Session Snapshot/Restore System**

* Added new methods to `SurfPaperNmsPlayerBridge` for creating/applying a `PlayerChatSessionSnapshot` and for safely locking the message signature cache. These are implemented for 1.26.1 and stubbed with `UnsupportedOperationException` for 1.21.11. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR27-R31) [[2]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R68-R82)
* Implemented full logic in `V26_1SurfPaperNmsPlayerBridgeImpl` to serialize and restore all relevant chat session state, including next chat index, chat session, last seen messages, message signature cache, and chat chain state.
* Introduced new data mirror classes: `PlayerChatSessionSnapshot`, `LastSeenMessagesValidatorMirror`, and `IncomingChatChainMirror`, with custom equality and serialization logic. [[1]](diffhunk://#diff-0b323a177e455796b3adf9ec96bdf097db87fb7a96c1f8b925b9aad2959c4d34R1-R13) [[2]](diffhunk://#diff-73864ccf979c73248d91db7863054c9d563df80884070e0772bfd57acf8ea9d5R1-R54)

**Reflection and Internal Accessors**

* Extended `V26_1NmsReflections` with new reflection methods and fields to access and mutate chat session internals, including chat index, message signature cache, last seen messages, signed message decoder, chat session, and chat visibility. [[1]](diffhunk://#diff-0204350fcea2bce676c0666957a2454ba0d7f79b4fff01d094d889710cc04147R36-R65) [[2]](diffhunk://#diff-0204350fcea2bce676c0666957a2454ba0d7f79b4fff01d094d889710cc04147R113-R139) [[3]](diffhunk://#diff-0204350fcea2bce676c0666957a2454ba0d7f79b4fff01d094d889710cc04147R149-R166)

**Other Changes**

* Bumped project version to 3.22.0 in `gradle.properties`.

These changes lay the groundwork for advanced chat state management, enabling features like chat session migration or rollback. The system is currently only supported in the 1.26.1 implementation.