### PR TITLE
Add ensureGlobalTickThread method for validation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.22.0
+version=3.23.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/region/V1_21_11TickThreadGuard.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/region/V1_21_11TickThreadGuard.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.api.paper.server.nms.v1_21_11.region
 
 import ca.spottedleaf.moonrise.common.util.TickThread
+import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.api.paper.region.TickThreadGuard
 import dev.slne.surf.api.paper.server.nms.v1_21_11.extensions.toNms
 import dev.slne.surf.api.paper.util.chunkX
@@ -61,5 +62,11 @@ class V1_21_11TickThreadGuard : TickThreadGuard {
         reason: String
     ) {
         TickThread.ensureTickThread(world.toNms(), blockX, blockZ, reason)
+    }
+
+    override fun ensureGlobalTickThread(reason: String) {
+        if (!server.isGlobalTickThread) {
+            throw IllegalStateException("Not on global tick thread: $reason")
+        }
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/region/V26_1TickThreadGuard.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/region/V26_1TickThreadGuard.kt
@@ -1,6 +1,7 @@
 package dev.slne.surf.api.paper.server.nms.v26_1.region
 
 import ca.spottedleaf.moonrise.common.util.TickThread
+import dev.slne.surf.api.paper.extensions.server
 import dev.slne.surf.api.paper.region.TickThreadGuard
 import dev.slne.surf.api.paper.server.nms.v26_1.extensions.toNms
 import dev.slne.surf.api.paper.util.chunkX
@@ -16,6 +17,8 @@ import org.bukkit.util.BoundingBox
 class V26_1TickThreadGuard : TickThreadGuard {
 
     override fun ensureTickThread(world: World, pos: Position, reason: String) {
+        TickThread.ensureTickThread("")
+
         TickThread.ensureTickThread(world.toNms(), pos.chunkX, pos.chunkZ, reason)
     }
 
@@ -61,5 +64,11 @@ class V26_1TickThreadGuard : TickThreadGuard {
         reason: String
     ) {
         TickThread.ensureTickThread(world.toNms(), blockX, blockZ, reason)
+    }
+
+    override fun ensureGlobalTickThread(reason: String) {
+        if (!server.isGlobalTickThread) {
+            throw IllegalStateException("Not on global tick thread: $reason")
+        }
     }
 }

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -2583,6 +2583,7 @@ public abstract class dev/slne/surf/api/paper/permission/PermissionRegistry {
 
 public abstract interface class dev/slne/surf/api/paper/region/TickThreadGuard {
 	public static final field Companion Ldev/slne/surf/api/paper/region/TickThreadGuard$Companion;
+	public abstract fun ensureGlobalTickThread (Ljava/lang/String;)V
 	public abstract fun ensureTickThread (Lorg/bukkit/World;DDLjava/lang/String;)V
 	public abstract fun ensureTickThread (Lorg/bukkit/World;IILjava/lang/String;)V
 	public abstract fun ensureTickThread (Lorg/bukkit/World;Lio/papermc/paper/math/Position;ILjava/lang/String;)V
@@ -2592,6 +2593,7 @@ public abstract interface class dev/slne/surf/api/paper/region/TickThreadGuard {
 }
 
 public final class dev/slne/surf/api/paper/region/TickThreadGuard$Companion : dev/slne/surf/api/paper/region/TickThreadGuard {
+	public fun ensureGlobalTickThread (Ljava/lang/String;)V
 	public fun ensureTickThread (Lorg/bukkit/World;DDLjava/lang/String;)V
 	public fun ensureTickThread (Lorg/bukkit/World;IILjava/lang/String;)V
 	public fun ensureTickThread (Lorg/bukkit/World;Lio/papermc/paper/math/Position;ILjava/lang/String;)V

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/region/TickThreadGuard.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/region/TickThreadGuard.kt
@@ -17,6 +17,8 @@ interface TickThreadGuard {
     fun ensureTickThread(world: World, box: BoundingBox, reason: String)
     fun ensureTickThread(world: World, blockX: Double, blockZ: Double, reason: String)
 
+    fun ensureGlobalTickThread(reason: String)
+
     companion object : TickThreadGuard by tickThreadGuard {
         val INSTANCE get() = tickThreadGuard
     }


### PR DESCRIPTION
This pull request introduces a new method, `ensureGlobalTickThread`, to the `TickThreadGuard` interface and implements it for both the `v1_21_11` and `v26_1` NMS versions. This addition allows for explicit checks to ensure code is running on the global tick thread, improving thread safety and error reporting. The project version is also updated.

### API changes

* Added the `ensureGlobalTickThread(reason: String)` method to the `TickThreadGuard` interface and its companion, updating the API contract and documentation. [[1]](diffhunk://#diff-41a5914f5cfd731b3485939188d2b52fa6a8adc4916c853bd946964886212e9eR20-R21) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R2586) [[3]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R2596)

### Implementation updates

* Implemented the new `ensureGlobalTickThread` method in both `V1_21_11TickThreadGuard` and `V26_1TickThreadGuard`, throwing an `IllegalStateException` if not on the global tick thread. [[1]](diffhunk://#diff-654ce8cd820b086208a2fa5d62696c63e53c61486710eb9e0e63346d2c79335fR66-R71) [[2]](diffhunk://#diff-4da71b25f3a23a1a7ce2d4f3d785322090696a5a96c84cddf77cc6fa39cff492R68-R73)
* Added necessary imports for `server` extension to support the global tick thread check in both NMS guard classes. [[1]](diffhunk://#diff-654ce8cd820b086208a2fa5d62696c63e53c61486710eb9e0e63346d2c79335fR4) [[2]](diffhunk://#diff-4da71b25f3a23a1a7ce2d4f3d785322090696a5a96c84cddf77cc6fa39cff492R4)

### Versioning

* Bumped project version from `3.22.0` to `3.23.0` in `gradle.properties`.