### PR TITLE
Add entity ID management and player tracking methods

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.1.2
 group=dev.slne.surf.api
-version=3.23.1
+version=3.24.0
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsEntityBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsEntityBridgeImpl.kt
@@ -15,6 +15,7 @@ import net.kyori.adventure.nbt.CompoundBinaryTag
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.commands.SummonCommand
 import org.bukkit.World
+import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 
 @NmsUseWithCaution
@@ -49,5 +50,13 @@ class V1_21_11SurfPaperNmsEntityBridgeImpl : SurfPaperNmsEntityBridge {
         } catch (e: CommandSyntaxException) {
             throw WrapperCommandSyntaxException(e)
         }
+    }
+
+    override fun setId(entity: Entity, id: Int) {
+        entity.toNms().id = id
+    }
+
+    override fun getById(world: World, id: Int): Entity? {
+        return world.toNms().getEntity(id)?.bukkitEntity
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v1-21-11/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v1_21_11/bridges/V1_21_11SurfPaperNmsPlayerBridgeImpl.kt
@@ -53,6 +53,38 @@ import kotlin.jvm.optionals.getOrNull
 
 @NmsUseWithCaution
 class V1_21_11SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
+
+    override fun removeAllTrackedEntities(player: Player, swallowExceptions: Boolean) {
+        val nmsPlayer = player.toNms()
+
+        val distance = player.viewDistance.toDouble()
+        player.getNearbyEntities(distance, distance, distance).forEach { entity ->
+            try {
+                entity.toNms().`moonrise$getTrackedEntity`().serverEntity.removePairing(nmsPlayer)
+            } catch (e: Throwable) {
+                if (!swallowExceptions) {
+                    throw e
+                }
+            }
+        }
+    }
+
+    override fun removeAllTrackedPlayers(player: Player, swallowExceptions: Boolean) {
+        val nmsPlayer = player.toNms()
+        val trackedEntity = nmsPlayer.`moonrise$getTrackedEntity`()
+
+        for (otherPlayer in MinecraftServer.getServer().playerList.players) {
+            if (otherPlayer.uuid == nmsPlayer.uuid) continue
+            try {
+                trackedEntity.serverEntity.removePairing(otherPlayer)
+            } catch (e: Throwable) {
+                if (!swallowExceptions) {
+                    throw e
+                }
+            }
+        }
+    }
+
     override fun getRemoteChatSessionData(player: Player): RemoteChatSessionData? {
         val session = player.toNms().chatSession?.asData() ?: return null
         val profilePublicKey = session.profilePublicKey()

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsEntityBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsEntityBridgeImpl.kt
@@ -15,6 +15,7 @@ import net.kyori.adventure.nbt.CompoundBinaryTag
 import net.minecraft.server.MinecraftServer
 import net.minecraft.server.commands.SummonCommand
 import org.bukkit.World
+import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 
 @NmsUseWithCaution
@@ -50,5 +51,13 @@ class V26_1SurfPaperNmsEntityBridgeImpl : SurfPaperNmsEntityBridge {
         } catch (e: CommandSyntaxException) {
             throw WrapperCommandSyntaxException(e)
         }
+    }
+
+    override fun setId(entity: Entity, id: Int) {
+        entity.toNms().id = id
+    }
+
+    override fun getById(world: World, id: Int): Entity? {
+        return world.toNms().getEntity(id)?.bukkitEntity
     }
 }

--- a/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
+++ b/surf-api-paper/surf-api-paper-nms/surf-api-paper-nms-v26-1/src/main/kotlin/dev/slne/surf/api/paper/server/nms/v26_1/bridges/V26_1SurfPaperNmsPlayerBridgeImpl.kt
@@ -54,6 +54,37 @@ import kotlin.jvm.optionals.getOrNull
 @Suppress("ClassName")
 class V26_1SurfPaperNmsPlayerBridgeImpl : SurfPaperNmsPlayerBridge {
 
+    override fun removeAllTrackedEntities(player: Player, swallowExceptions: Boolean) {
+        val nmsPlayer = player.toNms()
+
+        val distance = player.viewDistance.toDouble()
+        player.getNearbyEntities(distance, distance, distance).forEach { entity ->
+            try {
+                entity.toNms().`moonrise$getTrackedEntity`().serverEntity.removePairing(nmsPlayer)
+            } catch (e: Throwable) {
+                if (!swallowExceptions) {
+                    throw e
+                }
+            }
+        }
+    }
+
+    override fun removeAllTrackedPlayers(player: Player, swallowExceptions: Boolean) {
+        val nmsPlayer = player.toNms()
+        val trackedEntity = nmsPlayer.`moonrise$getTrackedEntity`()
+
+        for (otherPlayer in MinecraftServer.getServer().playerList.players) {
+            if (otherPlayer.uuid == nmsPlayer.uuid) continue
+            try {
+                trackedEntity.serverEntity.removePairing(otherPlayer)
+            } catch (e: Throwable) {
+                if (!swallowExceptions) {
+                    throw e
+                }
+            }
+        }
+    }
+
     @Suppress("USELESS_ELVIS")
     override fun getRemoteChatSessionData(player: Player): RemoteChatSessionData? {
         val connection = player.toNms().connection ?: return null

--- a/surf-api-paper/surf-api-paper/api/surf-api-paper.api
+++ b/surf-api-paper/surf-api-paper/api/surf-api-paper.api
@@ -1671,11 +1671,15 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsCommonBridge$
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge {
 	public static final field Companion Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge$Companion;
 	public abstract fun createEntityByNbt (Lorg/bukkit/World;Lorg/bukkit/entity/EntityType;Lio/papermc/paper/math/FinePosition;Lnet/kyori/adventure/nbt/CompoundBinaryTag;)V
+	public abstract fun getById (Lorg/bukkit/World;I)Lorg/bukkit/entity/Entity;
+	public abstract fun setId (Lorg/bukkit/entity/Entity;I)V
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge$Companion : dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge {
 	public fun createEntityByNbt (Lorg/bukkit/World;Lorg/bukkit/entity/EntityType;Lio/papermc/paper/math/FinePosition;Lnet/kyori/adventure/nbt/CompoundBinaryTag;)V
+	public fun getById (Lorg/bukkit/World;I)Lorg/bukkit/entity/Entity;
 	public final fun getINSTANCE ()Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge;
+	public fun setId (Lorg/bukkit/entity/Entity;I)V
 }
 
 public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsGlowingBridge {
@@ -1737,6 +1741,10 @@ public abstract interface class dev/slne/surf/api/paper/nms/bridges/SurfPaperNms
 	public abstract fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public abstract fun getStatsDataPath ()Ljava/nio/file/Path;
 	public abstract fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
+	public abstract fun removeAllTrackedEntities (Lorg/bukkit/entity/Player;Z)V
+	public static synthetic fun removeAllTrackedEntities$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lorg/bukkit/entity/Player;ZILjava/lang/Object;)V
+	public abstract fun removeAllTrackedPlayers (Lorg/bukkit/entity/Player;Z)V
+	public static synthetic fun removeAllTrackedPlayers$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lorg/bukkit/entity/Player;ZILjava/lang/Object;)V
 	public abstract fun resetPlayerChatState (Lorg/bukkit/entity/Player;Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;)V
 	public abstract fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public abstract fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
@@ -1756,6 +1764,8 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 	public fun getRemoteChatSessionData (Lorg/bukkit/entity/Player;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;
 	public fun getStatsDataPath ()Ljava/nio/file/Path;
 	public fun increaseNextChatIndex (Lorg/bukkit/entity/Player;)Ljava/lang/Integer;
+	public fun removeAllTrackedEntities (Lorg/bukkit/entity/Player;Z)V
+	public fun removeAllTrackedPlayers (Lorg/bukkit/entity/Player;Z)V
 	public fun resetPlayerChatState (Lorg/bukkit/entity/Player;Ldev/slne/surf/api/paper/nms/bridges/data/chat/RemoteChatSessionData;)V
 	public fun runOnChatMessageChain (Lorg/bukkit/entity/Player;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function1;)V
 	public fun sendPlayerChatMessage (Lorg/bukkit/entity/Player;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/chat/ChatType$Bound;)V
@@ -1765,6 +1775,8 @@ public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$DefaultImpls {
 	public static synthetic fun createPlayerChatMessageMirrorFromAdventure$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lnet/kyori/adventure/chat/SignedMessage;Lnet/kyori/adventure/text/Component;ILjava/lang/Object;)Ldev/slne/surf/api/paper/nms/bridges/data/chat/PlayerChatMessageMirror;
+	public static synthetic fun removeAllTrackedEntities$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lorg/bukkit/entity/Player;ZILjava/lang/Object;)V
+	public static synthetic fun removeAllTrackedPlayers$default (Ldev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge;Lorg/bukkit/entity/Player;ZILjava/lang/Object;)V
 }
 
 public final class dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge$PlayerInventoryEdit {

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsEntityBridge.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.api.paper.nms.NmsUseWithCaution
 import io.papermc.paper.math.FinePosition
 import net.kyori.adventure.nbt.CompoundBinaryTag
 import org.bukkit.World
+import org.bukkit.entity.Entity
 import org.bukkit.entity.EntityType
 
 @NmsUseWithCaution
@@ -15,6 +16,10 @@ interface SurfPaperNmsEntityBridge {
 
     @Throws(WrapperCommandSyntaxException::class)
     fun createEntityByNbt(world: World, type: EntityType, pos: FinePosition, tag: CompoundBinaryTag)
+
+    fun setId(entity: Entity, id: Int)
+
+    fun getById(world: World, id: Int): Entity?
 
     companion object : SurfPaperNmsEntityBridge by bridge {
         val INSTANCE get() = bridge

--- a/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
+++ b/surf-api-paper/surf-api-paper/src/main/kotlin/dev/slne/surf/api/paper/nms/bridges/SurfPaperNmsPlayerBridge.kt
@@ -22,6 +22,9 @@ import java.nio.file.Path
 @ApiStatus.NonExtendable
 interface SurfPaperNmsPlayerBridge {
 
+    fun removeAllTrackedEntities(player: Player, swallowExceptions: Boolean = true)
+    fun removeAllTrackedPlayers(player: Player, swallowExceptions: Boolean = true)
+
     fun getRemoteChatSessionData(player: Player): RemoteChatSessionData?
 
     fun createChatSessionSnapshot(player: Player): PlayerChatSessionSnapshot?


### PR DESCRIPTION
This pull request introduces new methods to the NMS bridge interfaces and their implementations, enhancing entity and player tracking control and access. The main focus is on adding functionality for manipulating entity IDs and managing tracked entities/players, along with the necessary API and implementation updates for Minecraft 1.21.1 and 1.26.1.

### API Additions and Interface Changes

* Added `setId` and `getById` methods to the `SurfPaperNmsEntityBridge` interface, allowing setting an entity's internal ID and retrieving an entity by ID within a world. [[1]](diffhunk://#diff-1352d7f153ffa4ef52889f3fd886b01f75630a98427dffc7861da8d066f3bfaaR20-R23) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1674-R1682)
* Added `removeAllTrackedEntities` and `removeAllTrackedPlayers` methods to the `SurfPaperNmsPlayerBridge` interface, enabling the removal of all tracked entities or players for a given player, with an option to swallow exceptions. [[1]](diffhunk://#diff-024c2c08199bc572246e21e46943486157521e5ec8b7517302863ec7265ffa0cR25-R27) [[2]](diffhunk://#diff-d8fe2c140212c6e1367c36c8e60304181ff2bc0e0806515632204e51b58013d5R1744-R1747)

### Implementation Updates

* Implemented the new `setId` and `getById` methods in both `V1_21_11SurfPaperNmsEntityBridgeImpl` and `V26_1SurfPaperNmsEntityBridgeImpl`. [[1]](diffhunk://#diff-223699734eba39796d15b1623a80dca8b5a093169a7bc685e15f03b48c74d8cfR54-R61) [[2]](diffhunk://#diff-0def0e010046daac0510e2a93d86b7b5a47bb345f288e93e6b08f8180474aad5R55-R62)
* Implemented the new `removeAllTrackedEntities` and `removeAllTrackedPlayers` methods in both `V1_21_11SurfPaperNmsPlayerBridgeImpl` and `V26_1SurfPaperNmsPlayerBridgeImpl`. [[1]](diffhunk://#diff-a29e78d443ba137ffa04ec9486bb0331db2d33aa371b6b4e8a9dd9079b99dfb4R56-R87) [[2]](diffhunk://#diff-997157bbdc6878be85e768d1cead56fa7824d0bb072af24534040a8a730047a6R57-R87)

### Versioning

* Bumped the project version from `3.23.1` to `3.24.0` in `gradle.properties`.