### PR TITLE
🔧 chore: update version to 3.27.5 and improve service loader fallback…

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.2
 group=dev.slne.surf.api
-version=3.27.4
+version=3.27.5
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/util/service-util.kt
+++ b/surf-api-core/surf-api-core/src/main/kotlin/dev/slne/surf/api/core/util/service-util.kt
@@ -13,19 +13,22 @@ import java.util.*
  * @return the service instance of type [T]
  * @throws ServiceConfigurationError if the service of type [T] is not available
  */
-inline fun <reified T : Any> requiredService(): T = ServiceUtil.serviceWithFallback<T>(
-    ServiceLoader.load(
-        T::class.java,
-        getCallerClass(-1)?.classLoader ?: T::class.java.classLoader
-    ), T::class.java
-) ?: throw ServiceConfigurationError("Service ${T::class.java.name} not available")
+inline fun <reified T : Any> requiredService(): T = ServiceUtil.serviceWithFallback(T::class.java)
+    ?: throw ServiceConfigurationError("Service ${T::class.java.name} not available")
 
 object ServiceUtil {
     @Suppress("UnstableApiUsage")
     private val SERVICE_LOAD_FAILURES_ARE_FATAL = AdventureProperties.SERVICE_LOAD_FAILURES_ARE_FATAL.value() == true
 
+    @Deprecated("Binary compatibility", ReplaceWith("serviceWithFallback(loader, type)"), DeprecationLevel.HIDDEN)
     @PublishedApi
     internal fun <T : Any> serviceWithFallback(loader: ServiceLoader<T>, type: Class<T>): T? {
+        return serviceWithFallback(type)
+    }
+
+    @PublishedApi
+    internal fun <T : Any> serviceWithFallback(type: Class<T>): T? {
+        val loader = ServiceLoader.load(type, type.classLoader)
         val iterator = loader.iterator()
         var firstFallback: T? = null
 


### PR DESCRIPTION
… method

- increment version in gradle.properties to 3.27.5
- refactor requiredService function to simplify service loading logic
- add deprecated method for binary compatibility with existing code