### PR TITLE
Update shadowJar task to relocate fastutil package

### DIFF
--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 group = groupId
 version = buildString {
-    append("2.1.0")
+    append("2.1.1")
     if (snapshot) append("-SNAPSHOT")
 }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
@@ -212,6 +212,7 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
         jvmToolchain(Constants.JAVA_VERSION)
         compilerOptions {
             freeCompilerArgs.addAll(listOf("-Xjsr305=strict", "-Xcontext-parameters"))
+            javaParameters = true
         }
     }
 

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/minestom/MinestomSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/minestom/MinestomSurfPlugin.kt
@@ -7,5 +7,11 @@ internal class MinestomSurfPlugin : AbstractCoreSurfPlugin<MinestomSurfExtension
     platformName = "minestom",
     platform = SurfApiPlatform.MINESTOM,
 ) {
+    init {
+        "it.unimi.dsi.fastutil" relocatesTo "fastutil"
+    }
+
     override val extensionClass = MinestomSurfExtension::class.java
+
+
 }

--- a/surf-api-minestom/build.gradle.kts
+++ b/surf-api-minestom/build.gradle.kts
@@ -30,3 +30,10 @@ description = "surf-api-minestom"
 
 private fun <T : ModuleDependency> T.exclude(provider: Provider<MinimalExternalModuleDependency>) =
     provider.get().module.apply { exclude(group, name) }
+
+tasks {
+    shadowJar {
+        val relocationPrefix: String by project
+        relocate("it.unimi.dsi.fastutil", "$relocationPrefix.fastutil")
+    }
+}


### PR DESCRIPTION
This pull request introduces improvements to dependency management and build configuration for the Minestom platform. The main changes focus on relocating the `fastutil` library to avoid conflicts, and enhancing compiler settings for better debugging and compatibility.

**Dependency relocation:**

* Added logic to relocate the `it.unimi.dsi.fastutil` package to a project-specific namespace in the `shadowJar` task in `surf-api-minestom/build.gradle.kts`, preventing dependency clashes.
* Configured the Minestom plugin to relocate `it.unimi.dsi.fastutil` to `fastutil`, ensuring runtime isolation.

**Build configuration improvements:**

* Enabled `javaParameters` in the Kotlin compiler options within `CommonSurfPlugin`, which improves reflection and debugging capabilities by retaining parameter names.