### PR TITLE
✨ feat(testing): introduce unified testing infrastructure and add pla…

### DIFF
--- a/buildSrc/src/main/kotlin/core-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/core-convention.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     `java-library`
     id("publish-convention")
     id("java-toolchain-convention")
+    id("test-convention")
 
     kotlin("jvm")
     kotlin("plugin.serialization")

--- a/buildSrc/src/main/kotlin/test-convention.gradle.kts
+++ b/buildSrc/src/main/kotlin/test-convention.gradle.kts
@@ -1,0 +1,27 @@
+import org.gradle.accessors.dm.LibrariesForLibs
+
+val libs = the<LibrariesForLibs>()
+
+plugins {
+    `java-library`
+    kotlin("jvm")
+}
+
+configurations.testImplementation {
+    extendsFrom(configurations.compileOnlyApi.get())
+}
+
+dependencies {
+    testImplementation(kotlin("test"))
+    testImplementation(libs.junit.jupiter)
+    testImplementation(libs.mockk)
+    testImplementation(libs.lincheck)
+    testImplementation(libs.kotlinxCoroutines.test)
+    testRuntimeOnly(libs.junit.platform.launcher)
+}
+
+tasks.withType<Test>().configureEach {
+    useJUnitPlatform()
+    // Lincheck attaches its bytecode-instrumentation agent dynamically at runtime
+    jvmArgs("-XX:+EnableDynamicAgentLoading")
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
 javaVersion=25
 mcVersion=26.2
 group=dev.slne.surf.api
-version=3.36.0
+version=3.36.1
 relocationPrefix=dev.slne.surf.api.libs
 snapshot=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -66,6 +66,14 @@ ksp-version = "2.3.9"
 reactor-netty = "1.3.5"
 bytebuddy = "1.18.8"
 
+# Testing
+junit = "5.14.4"
+junit-platform-launcher = "1.14.4"
+mockk = "1.14.11"
+lincheck = "3.7"
+mockbukkit = "4.116.1"
+minestom-testing = "2026.08.16-26.2"
+
 # Plugin versions
 maven-repo-auth = "3.0.4"
 shadow-gradle-plugin = "9.4.1"
@@ -173,6 +181,16 @@ ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx
 reactor-netty-core = { module = "io.projectreactor.netty:reactor-netty-core", version.ref = "reactor-netty" }
 reactor-netty-http = { module = "io.projectreactor.netty:reactor-netty-http", version.ref = "reactor-netty" }
 bytebuddy = { module = "net.bytebuddy:byte-buddy", version.ref = "bytebuddy" }
+
+# Testing
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter", version.ref = "junit" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version.ref = "junit-platform-launcher" }
+mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+lincheck = { module = "org.jetbrains.lincheck:lincheck", version.ref = "lincheck" }
+# Artifact name tracks the Minecraft version this branch targets (mcVersion=26.2 in gradle.properties)
+mockbukkit = { module = "org.mockbukkit.mockbukkit:mockbukkit-v26.2", version.ref = "mockbukkit" }
+minestom-testing = { module = "net.minestom:testing", version.ref = "minestom-testing" }
+kotlinxCoroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinxCoroutines" }
 
 # Plugin dependencies
 kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinVersion" }

--- a/surf-api-core/surf-api-core/src/test/kotlin/dev/slne/surf/api/core/algorithms/KahnTopologicalSortTest.kt
+++ b/surf-api-core/surf-api-core/src/test/kotlin/dev/slne/surf/api/core/algorithms/KahnTopologicalSortTest.kt
@@ -1,0 +1,55 @@
+package dev.slne.surf.api.core.algorithms
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class KahnTopologicalSortTest {
+
+    @Test
+    fun `empty graph sorts to empty list`() {
+        assertTrue(emptyMap<String, List<String>>().topologicalSort().isEmpty())
+    }
+
+    @Test
+    fun `linear chain keeps order`() {
+        val graph = mapOf("a" to listOf("b"), "b" to listOf("c"))
+        assertEquals(listOf("a", "b", "c"), graph.topologicalSort())
+    }
+
+    @Test
+    fun `diamond respects partial order`() {
+        val graph = mapOf(
+            "root" to listOf("left", "right"),
+            "left" to listOf("sink"),
+            "right" to listOf("sink"),
+        )
+        val order = graph.topologicalSort()
+        assertEquals(4, order.size)
+        assertPartialOrder(graph, order)
+    }
+
+    @Test
+    fun `vertex appearing only as successor is included`() {
+        val graph = mapOf("a" to listOf("b"))
+        assertEquals(listOf("a", "b"), graph.topologicalSort())
+    }
+
+    @Test
+    fun `cycle returns failure`() {
+        val graph = mapOf("a" to listOf("b"), "b" to listOf("a"))
+        assertTrue(graph.topologicalSortSafe().isFailure)
+    }
+
+    private fun <T> assertPartialOrder(graph: Map<T, List<T>>, order: List<T>) {
+        val index = order.withIndex().associate { (i, v) -> v to i }
+        graph.forEach { (from, successors) ->
+            successors.forEach { to ->
+                assertTrue(
+                    index.getValue(from) < index.getValue(to),
+                    "$from must be ordered before $to",
+                )
+            }
+        }
+    }
+}

--- a/surf-api-core/surf-api-core/src/test/kotlin/dev/slne/surf/api/core/component/AbstractComponentLincheckTest.kt
+++ b/surf-api-core/surf-api-core/src/test/kotlin/dev/slne/surf/api/core/component/AbstractComponentLincheckTest.kt
@@ -1,0 +1,54 @@
+package dev.slne.surf.api.core.component
+
+import dev.slne.surf.api.shared.api.component.SurfComponentMeta
+import dev.slne.surf.api.shared.api.util.InternalSurfApi
+import kotlinx.coroutines.runBlocking
+import org.jetbrains.lincheck.Lincheck
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(InternalSurfApi::class)
+class AbstractComponentLincheckTest {
+
+    @SurfComponentMeta
+    private class CountingComponent : AbstractComponent() {
+        val loadCalls = AtomicInteger()
+        val enableCalls = AtomicInteger()
+        val disableCalls = AtomicInteger()
+
+        override suspend fun onLoad() {
+            loadCalls.incrementAndGet()
+        }
+
+        override suspend fun onEnable() {
+            enableCalls.incrementAndGet()
+        }
+
+        override suspend fun onDisable() {
+            disableCalls.incrementAndGet()
+        }
+    }
+
+    @Test
+    fun `lifecycle phases execute at most once under concurrent invocation`() {
+        Lincheck.runConcurrentTest {
+            val component = CountingComponent()
+            val threads = List(2) {
+                Thread {
+                    runBlocking {
+                        component.load()
+                        component.enable()
+                        component.disable()
+                    }
+                }
+            }
+            threads.forEach(Thread::start)
+            threads.forEach(Thread::join)
+
+            assertEquals(1, component.loadCalls.get(), "onLoad must run exactly once")
+            assertEquals(1, component.enableCalls.get(), "onEnable must run exactly once")
+            assertEquals(1, component.disableCalls.get(), "onDisable must run exactly once")
+        }
+    }
+}

--- a/surf-api-gradle-plugin/build.gradle.kts
+++ b/surf-api-gradle-plugin/build.gradle.kts
@@ -20,7 +20,7 @@ plugins {
 
 group = groupId
 version = buildString {
-    append("2.1.4")
+    append("2.2.0")
     if (snapshot) append("-SNAPSHOT")
 }
 
@@ -130,6 +130,16 @@ val generateConstants by tasks.registering {
         "version",
         rootProject.findProperty("version") as String + if (snapshot) "-SNAPSHOT" else ""
     )
+    inputs.property("libs.versions.junit", libs.versions.junit.asProvider().get())
+    inputs.property(
+        "libs.versions.junit.platform.launcher",
+        libs.versions.junit.platform.launcher.get()
+    )
+    inputs.property("libs.versions.mockk", libs.versions.mockk.get())
+    inputs.property("libs.versions.lincheck", libs.versions.lincheck.get())
+    inputs.property("libs.versions.mockbukkit", libs.versions.mockbukkit.get())
+    inputs.property("libs.versions.minestom.testing", libs.versions.minestom.testing.get())
+    inputs.property("libs.versions.kotlinxCoroutines", libs.versions.kotlinxCoroutines.get())
     outputs.dir(constantsOutputDir)
 
     doLast {
@@ -155,6 +165,14 @@ val generateConstants by tasks.registering {
             |    const val PLACEHOLDER_API_VERSION = "${libs.versions.placeholder.api.get()}"
             |    const val LUCKPERMS_VERSION = "${libs.versions.luckperms.get()}"
             |    const val PACKETEVENTS_VERSION = "${libs.versions.packetevents.plugin.get()}"
+            |
+            |    const val TEST_JUNIT_VERSION = "${libs.versions.junit.asProvider().get()}"
+            |    const val TEST_JUNIT_PLATFORM_LAUNCHER_VERSION = "${libs.versions.junit.platform.launcher.get()}"
+            |    const val TEST_MOCKK_VERSION = "${libs.versions.mockk.get()}"
+            |    const val TEST_LINCHECK_VERSION = "${libs.versions.lincheck.get()}"
+            |    const val TEST_MOCKBUKKIT_VERSION = "${libs.versions.mockbukkit.get()}"
+            |    const val TEST_MINESTOM_TESTING_VERSION = "${libs.versions.minestom.testing.get()}"
+            |    const val TEST_COROUTINES_VERSION = "${libs.versions.kotlinxCoroutines.get()}"
             |
             |    const val SURF_API_FULL_VERSION = "${rootProject.findProperty("version") as String + if (snapshot) "-SNAPSHOT" else ""}"
             |}

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfExtension.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfExtension.kt
@@ -1,7 +1,10 @@
 package dev.slne.surf.api.gradle.platform.common
 
 import dev.slne.surf.api.gradle.SurfCoreModules
+import dev.slne.surf.api.gradle.platform.common.testing.SurfTestingExtension
+import org.gradle.api.Action
 import org.gradle.api.model.ObjectFactory
+import org.gradle.kotlin.dsl.newInstance
 import org.gradle.kotlin.dsl.property
 import org.jetbrains.annotations.MustBeInvokedByOverriders
 
@@ -20,6 +23,12 @@ abstract class CommonSurfExtension(protected val objects: ObjectFactory) {
     internal val surfDatabaseR2dbcVersion = objects.property<String>()
     internal val surfDatabaseR2dbcRelocation = objects.property<String>()
     internal val withApiValidation = objects.property<Boolean>().convention(false)
+
+    val testing: SurfTestingExtension = objects.newInstance<SurfTestingExtension>()
+
+    fun testing(action: Action<SurfTestingExtension>) {
+        action.execute(testing)
+    }
 
     fun withApiValidation() {
         withApiValidation.set(true)

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/CommonSurfPlugin.kt
@@ -3,6 +3,7 @@ package dev.slne.surf.api.gradle.platform.common
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import dev.slne.surf.api.gradle.generated.Constants
 import dev.slne.surf.api.gradle.platform.SurfApiPlatform
+import dev.slne.surf.api.gradle.platform.common.testing.SurfTestingConfigurer
 import dev.slne.surf.api.gradle.platform.core.CoreSurfExtension
 import dev.slne.surf.api.gradle.util.slnePublic
 import org.gradle.api.Plugin
@@ -137,7 +138,7 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
             val depsProvider = project.provider {
                 val deps = project.configurations
                     .asSequence()
-                    .filter { it.isCanBeResolved }
+                    .filter { it.isCanBeResolved && !it.name.startsWith("test") }
                     .flatMap { cfg -> cfg.incoming.resolutionResult.allDependencies.asSequence() }
                     .toList()
 
@@ -225,19 +226,25 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
     }
 
     private fun Project.afterEvaluated(extension: E) {
+        val testingEnabled = extension.testing.enabled.get()
+
         if (extension.addSurfApiToClasspath.get()) {
             dependencies {
                 val scope = extension.surfApiScope.orNull ?: platform.scope
                 add(scope, platform.dependency)
+                if (testingEnabled && (scope == COMPILE_ONLY || scope == "compileOnlyApi")) {
+                    add(SurfTestingConfigurer.TEST_IMPLEMENTATION, platform.dependency)
+                }
             }
         }
 
         extension.coreModule.orNull?.let {
             dependencies {
-                add(
-                    COMPILE_ONLY,
-                    "dev.slne.surf.core:${it.module}:+"
-                )
+                val notation = "dev.slne.surf.core:${it.module}:+"
+                add(COMPILE_ONLY, notation)
+                if (testingEnabled) {
+                    add(SurfTestingConfigurer.TEST_IMPLEMENTATION, notation)
+                }
             }
         }
 
@@ -253,10 +260,11 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
                 }
             } else {
                 dependencies {
-                    add(
-                        COMPILE_ONLY,
-                        "dev.slne.surf.redis:surf-redis-api:+"
-                    )
+                    val notation = "dev.slne.surf.redis:surf-redis-api:+"
+                    add(COMPILE_ONLY, notation)
+                    if (testingEnabled) {
+                        add(SurfTestingConfigurer.TEST_IMPLEMENTATION, notation)
+                    }
                 }
             }
         }
@@ -283,6 +291,11 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
             }
         }
 
+        if (testingEnabled) {
+            SurfTestingConfigurer.configure(this, extension.testing)
+            platformTestDependencies(extension)
+        }
+
         afterEvaluated0(extension)
     }
 
@@ -295,6 +308,9 @@ abstract class CommonSurfPlugin<E : CommonSurfExtension>(
     }
 
     protected open fun Project.afterEvaluated0(extension: E) {
+    }
+
+    protected open fun Project.platformTestDependencies(extension: E) {
     }
 
     private data class Relocation(

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/testing/SurfTestingConfigurer.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/testing/SurfTestingConfigurer.kt
@@ -1,0 +1,47 @@
+package dev.slne.surf.api.gradle.platform.common.testing
+
+import org.gradle.api.Project
+import org.gradle.api.tasks.testing.Test
+import org.gradle.kotlin.dsl.dependencies
+import org.gradle.kotlin.dsl.withType
+
+internal object SurfTestingConfigurer {
+    internal const val TEST_IMPLEMENTATION = "testImplementation"
+    internal const val TEST_RUNTIME_ONLY = "testRuntimeOnly"
+
+    fun configure(project: Project, testing: SurfTestingExtension) = with(project) {
+        tasks.withType<Test>().configureEach {
+            if (testing.useJUnitPlatform.get()) {
+                useJUnitPlatform()
+            }
+            // Lincheck attaches its bytecode-instrumentation agent dynamically at runtime
+            jvmArgs("-XX:+EnableDynamicAgentLoading")
+        }
+
+        dependencies {
+            add(
+                TEST_IMPLEMENTATION,
+                "org.junit.jupiter:junit-jupiter:${testing.junitVersion.get()}"
+            )
+            add(
+                TEST_RUNTIME_ONLY,
+                "org.junit.platform:junit-platform-launcher:${testing.junitPlatformLauncherVersion.get()}"
+            )
+            add(TEST_IMPLEMENTATION, "org.jetbrains.kotlin:kotlin-test-junit5")
+            add(
+                TEST_IMPLEMENTATION,
+                "org.jetbrains.kotlinx:kotlinx-coroutines-test:${testing.coroutinesTestVersion.get()}"
+            )
+
+            if (testing.mockk.get()) {
+                add(TEST_IMPLEMENTATION, "io.mockk:mockk:${testing.mockkVersion.get()}")
+            }
+            if (testing.lincheck.get()) {
+                add(
+                    TEST_IMPLEMENTATION,
+                    "org.jetbrains.lincheck:lincheck:${testing.lincheckVersion.get()}"
+                )
+            }
+        }
+    }
+}

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/testing/SurfTestingExtension.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/common/testing/SurfTestingExtension.kt
@@ -1,0 +1,40 @@
+package dev.slne.surf.api.gradle.platform.common.testing
+
+import dev.slne.surf.api.gradle.generated.Constants
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.Property
+import org.gradle.kotlin.dsl.property
+import javax.inject.Inject
+
+/**
+ * Configures the default-on testing support.
+ *
+ * All toggles default to enabled; versions default to the values baked into the
+ * plugin at build time. Surf-internal dependencies mirrored onto the test
+ * classpath keep their dynamic `+` version.
+ */
+open class SurfTestingExtension @Inject constructor(objects: ObjectFactory) {
+    val enabled: Property<Boolean> = objects.property<Boolean>().convention(true)
+
+    val useJUnitPlatform: Property<Boolean> = objects.property<Boolean>().convention(true)
+
+    val mockk: Property<Boolean> = objects.property<Boolean>().convention(true)
+    val lincheck: Property<Boolean> = objects.property<Boolean>().convention(true)
+    val mockBukkit: Property<Boolean> = objects.property<Boolean>().convention(true)
+    val minestomTesting: Property<Boolean> = objects.property<Boolean>().convention(true)
+
+    val junitVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_JUNIT_VERSION)
+    val junitPlatformLauncherVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_JUNIT_PLATFORM_LAUNCHER_VERSION)
+    val mockkVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_MOCKK_VERSION)
+    val lincheckVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_LINCHECK_VERSION)
+    val mockBukkitVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_MOCKBUKKIT_VERSION)
+    val minestomTestingVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_MINESTOM_TESTING_VERSION)
+    val coroutinesTestVersion: Property<String> =
+        objects.property<String>().convention(Constants.TEST_COROUTINES_VERSION)
+}

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/minestom/MinestomSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/minestom/MinestomSurfPlugin.kt
@@ -1,7 +1,10 @@
 package dev.slne.surf.api.gradle.platform.minestom
 
 import dev.slne.surf.api.gradle.platform.SurfApiPlatform
+import dev.slne.surf.api.gradle.platform.common.testing.SurfTestingConfigurer
 import dev.slne.surf.api.gradle.platform.core.AbstractCoreSurfPlugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.dependencies
 
 internal class MinestomSurfPlugin : AbstractCoreSurfPlugin<MinestomSurfExtension>(
     platformName = "minestom",
@@ -14,5 +17,14 @@ internal class MinestomSurfPlugin : AbstractCoreSurfPlugin<MinestomSurfExtension
 
     override val extensionClass = MinestomSurfExtension::class.java
 
-
+    override fun Project.platformTestDependencies(extension: MinestomSurfExtension) {
+        val testing = extension.testing
+        if (!testing.minestomTesting.get()) return
+        dependencies {
+            add(
+                SurfTestingConfigurer.TEST_IMPLEMENTATION,
+                "net.minestom:testing:${testing.minestomTestingVersion.get()}"
+            )
+        }
+    }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/AbstractPaperSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/AbstractPaperSurfPlugin.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.api.gradle.platform.paper
 
 import dev.slne.surf.api.gradle.generated.Constants
 import dev.slne.surf.api.gradle.platform.SurfApiPlatform
+import dev.slne.surf.api.gradle.platform.common.testing.SurfTestingConfigurer
 import dev.slne.surf.api.gradle.platform.core.AbstractCoreSurfPlugin
 import dev.slne.surf.api.gradle.util.canvasMaven
 import org.gradle.api.Project
@@ -47,5 +48,26 @@ internal abstract class AbstractPaperSurfPlugin<E : AbstractPaperSurfExtension>(
 
     open fun Project.afterEvaluated2(extension: E) {
 
+    }
+
+    final override fun Project.platformTestDependencies(extension: E) {
+        val testing = extension.testing
+
+        dependencies {
+            val platformApi =
+                if (extension.useCanvasMc.get()) Constants.CANVAS_API else Constants.PAPER_API
+            add(SurfTestingConfigurer.TEST_IMPLEMENTATION, platformApi)
+
+            if (testing.mockBukkit.get()) {
+                val mcMajorMinor = Constants.MINECRAFT_VERSION
+                    .split('.')
+                    .take(2)
+                    .joinToString(".")
+                add(
+                    SurfTestingConfigurer.TEST_IMPLEMENTATION,
+                    "org.mockbukkit.mockbukkit:mockbukkit-v$mcMajorMinor:${testing.mockBukkitVersion.get()}"
+                )
+            }
+        }
     }
 }

--- a/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
+++ b/surf-api-gradle-plugin/src/main/kotlin/dev/slne/surf/api/gradle/platform/paper/plugin/PaperPluginSurfPlugin.kt
@@ -2,6 +2,7 @@ package dev.slne.surf.api.gradle.platform.paper.plugin
 
 import dev.slne.surf.api.gradle.generated.Constants
 import dev.slne.surf.api.gradle.generators.LibrariesLoaderGenerator.generateLibrariesLoaderTask
+import dev.slne.surf.api.gradle.platform.common.testing.SurfTestingConfigurer
 import dev.slne.surf.api.gradle.platform.paper.AbstractPaperSurfPlugin
 import dev.slne.surf.api.gradle.util.registerRequired
 import net.minecrell.pluginyml.GeneratePluginDescription
@@ -33,7 +34,11 @@ internal class PaperPluginSurfPlugin :
         )
 
         if (extension.installSurfNpc.get()) {
-            dependencies.add(COMPILE_ONLY, "dev.slne.surf.npc:surf-npc-api:+")
+            val notation = "dev.slne.surf.npc:surf-npc-api:+"
+            dependencies.add(COMPILE_ONLY, notation)
+            if (extension.testing.enabled.get()) {
+                dependencies.add(SurfTestingConfigurer.TEST_IMPLEMENTATION, notation)
+            }
         }
 
         configure<PaperPluginDescription> {

--- a/surf-api-minestom/build.gradle.kts
+++ b/surf-api-minestom/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     api(libs.inventory.framework.platform.minestom)
     implementation(libs.packetevents.netty.common)
     runtimeOnly(libs.flogger.slf4j.backend)
+
+    testImplementation(libs.minestom.testing)
 }
 
 description = "surf-api-minestom"

--- a/surf-api-minestom/src/test/kotlin/dev/slne/surf/api/minestom/MinestomEnvSmokeTest.kt
+++ b/surf-api-minestom/src/test/kotlin/dev/slne/surf/api/minestom/MinestomEnvSmokeTest.kt
@@ -1,0 +1,17 @@
+package dev.slne.surf.api.minestom
+
+import net.minestom.testing.Env
+import net.minestom.testing.EnvTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
+
+@EnvTest
+class MinestomEnvSmokeTest {
+
+    @Test
+    fun `environment boots and creates a flat instance`(env: Env) {
+        val instance = env.createFlatInstance()
+        assertNotNull(instance)
+        env.destroyInstance(instance)
+    }
+}

--- a/surf-api-paper/surf-api-paper/build.gradle.kts
+++ b/surf-api-paper/surf-api-paper/build.gradle.kts
@@ -14,6 +14,9 @@ dependencies {
     api(libs.scoreboard.library.api)
     api(libs.commandapi.bukkit.kotlin)
     compileOnlyApi(libs.mccoroutine.folia.api)
+
+    testImplementation(libs.mockbukkit)
+    testImplementation(libs.paper.api)
 }
 
 description = "surf-api-paper"

--- a/surf-api-paper/surf-api-paper/src/test/kotlin/dev/slne/surf/api/paper/MockBukkitSmokeTest.kt
+++ b/surf-api-paper/surf-api-paper/src/test/kotlin/dev/slne/surf/api/paper/MockBukkitSmokeTest.kt
@@ -1,0 +1,32 @@
+package dev.slne.surf.api.paper
+
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.mockbukkit.mockbukkit.MockBukkit
+import org.mockbukkit.mockbukkit.ServerMock
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class MockBukkitSmokeTest {
+
+    private lateinit var server: ServerMock
+
+    @BeforeEach
+    fun setUp() {
+        server = MockBukkit.mock()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        MockBukkit.unmock()
+    }
+
+    @Test
+    fun `server mock boots and serves basic api`() {
+        assertNotNull(server.bukkitVersion)
+        val world = server.addSimpleWorld("smoke")
+        assertNotNull(world)
+        assertTrue(server.worlds.isNotEmpty())
+    }
+}


### PR DESCRIPTION
…tform-specific test dependencies

- add `SurfTestingExtension` to configure and manage default testing settings
- integrate testing support for Paper, Minestom, and core modules
- support frameworks like JUnit, MockK, and Lincheck with dynamic configuration
- include smoke tests for MockBukkit, KahnTopologicalSort, and Minestom environments
- update version to 3.36.1 in `gradle.properties`